### PR TITLE
suppression de la table des ressources désuete, remplacement par des liens

### DIFF
--- a/docs/cluster_intro.rst
+++ b/docs/cluster_intro.rst
@@ -98,7 +98,7 @@ sections for more details.
    This cluster is to be used for regular development and relatively small
    number of jobs (< 5)
 
-See `https://dashboard.server.mila.quebec`_ for a dynamically updated list of
+See `<https://dashboard.server.mila.quebec>`_ for a dynamically updated list of
 available resources.
 
 :ref:`Compute Canada Clusters <cc_clusters>` The clusters Beluga, Cedar,
@@ -106,5 +106,5 @@ available resources.
    have allocations. These are to be used for many jobs, multi-nodes and/or
    multi-GPU jobs as well as long running jobs
 
-See `https://www.computecanada.ca/techrenewal/national-systems/`_ for a
+See `<https://www.computecanada.ca/techrenewal/national-systems/>`_ for a
 complete list of computing capacity offered by Compute Canada.

--- a/docs/cluster_intro.rst
+++ b/docs/cluster_intro.rst
@@ -101,7 +101,8 @@ sections for more details.
 See `<https://dashboard.server.mila.quebec>`_ for a dynamically updated list of
 available resources.
 
-:ref:`Compute Canada Clusters <cc_clusters>` The clusters Beluga, Cedar,
+:ref:`Compute Canada Clusters <cc_clusters>`
+The clusters Beluga, Cedar,
    Graham, Helios and Niagara are clusters provided by Compute Canada on which we
    have allocations. These are to be used for many jobs, multi-nodes and/or
    multi-GPU jobs as well as long running jobs

--- a/docs/cluster_intro.rst
+++ b/docs/cluster_intro.rst
@@ -91,33 +91,20 @@ the end of the job execution for the next job to come along.
 Resources Available at Mila
 ----------------------------
 
-This table contains the computational resources Mila has access to.
-
-.. Warning:: This table is outdated and needs to be revisited.
-
-================================ ================================ ====
-Cluster                          CPUs                             GPUs
-================================ ================================ ====
-:ref:`Mila <milacluster>`                                         248
--------------------------------- -------------------------------- ----
-:ref:`Beluga <beluga>`           34k                              688 V100
--------------------------------- -------------------------------- ----
-:ref:`Cedar <cedar>`             27k                              584 P100
--------------------------------- -------------------------------- ----
-:ref:`Graham <graham>`           36k                              320 P100
--------------------------------- -------------------------------- ----
-Helios                                                            216 k80
--------------------------------- -------------------------------- ----
-Niagara                          60k
--------------------------------- -------------------------------- ----
-Total                            134k                             2040
-================================ ================================ ====
+This section contains the computational resources Mila has access to. See
+sections for more details.
 
 :ref:`Mila Cluster <milacluster>`
    This cluster is to be used for regular development and relatively small
    number of jobs (< 5)
 
+See `https://dashboard.server.mila.quebec`_ for a dynamically updated list of
+available resources.
+
 :ref:`Compute Canada Clusters <cc_clusters>` The clusters Beluga, Cedar,
    Graham, Helios and Niagara are clusters provided by Compute Canada on which we
    have allocations. These are to be used for many jobs, multi-nodes and/or
    multi-GPU jobs as well as long running jobs
+
+See `https://www.computecanada.ca/techrenewal/national-systems/`_ for a
+complete list of computing capacity offered by Compute Canada.


### PR DESCRIPTION
Remplacer la table des ressources Mila + Qc qui n'était plus à jour par des liens vers les références en la matière (site WEB CC + Dashboard mila)