### PR TITLE
Limit build_the_docs action to the master branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ name: 'build_the_docs'
 
 on:
   push:
+    branches:
+      - master
 
 jobs:
 


### PR DESCRIPTION
Otherwise, a push to any branch will trigger the build and publish the
website.

See https://github.com/mila-iqia/mila-docs/actions/runs/873513858 where an update to an in-progress PR was published.