### PR TITLE
Add collapsible boxes and reorganize the index

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,3 +86,18 @@ There are no heading levels assigned to certain characters as the structure is d
    This is a long
    long long note
 ```
+
+### Collapsible boxes
+
+This is a local extension, not part of Sphinx itself.  It works like this:
+
+```reST
+.. container:: toggle
+
+    .. container:: header
+
+        **Show/Hide Code**
+
+    .. code-block:: <type>
+       ...
+```

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -17,3 +17,16 @@ pre.highlight span[class^="prompt"] {
   font-size: 12px;
   line-height: 1.4;
 }
+
+.toggle .header {
+    display: block;
+    clear: both;
+}
+
+.toggle .header:after {
+    content: " ▶";
+}
+
+.toggle .header.open:after {
+    content: " ▼";
+}

--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -1,0 +1,14 @@
+{% extends "!footer.html" %}
+
+{% block extrafooter %}
+<script type="text/javascript">
+  window.onload = function() {
+      $(".toggle > *").hide();
+      $(".toggle .header").show();
+      $(".toggle .header").click(function() {
+          $(this).parent().children().not(".header").toggle(400);
+          $(this).parent().children(".header").toggleClass("open");
+      })
+  };
+</script>
+{% endblock %}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,15 +9,40 @@ Welcome to Mila's technical documentation. See contents below.
 .. Link to chapters below.
 
 .. toctree::
-   :numbered:
+   :caption: Purpose
    :maxdepth: 2
 
    Purpose
+
+.. toctree::
+   :caption: Cluster Theory
+   :maxdepth: 2
+
    Theory_cluster
+
+.. toctree::
+   :caption: Information
+   :maxdepth: 2
+
    Information
-   Userguide
-   Handbook
    Extra_compute
+
+.. toctree::
+   :caption: User Guide
+   :maxdepth: 2
+
+   Userguide
+
+.. toctree::
+   :caption: Handbook
+   :maxdepth: 2
+
+   Handbook
+
+.. toctree::
+   :caption: Extras
+   :maxdepth: 2
+
    Audio_video
    IDT
 


### PR DESCRIPTION
This is two independent changes, so if there is resistance to one but not the other, they could be split in two PRs

The first one reorganizes the index bringing back the section headers from before while still mostly respecting the new structure.

The second one add a way to make collapsible boxes in html output by patching the theme (If we switch theme this might require minor adjustments).  It doesn't use it anywhere but there is an example in the CONTRIBUTING file.