### PR TITLE
Fix search-bar by removing outdated neo_rtd_theme 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ html_js_files = ['documentation_options.js', 'documentation_options_fix.js']
 #
 # html_sidebars = {}
 #---sphinx-themes-----
-html_theme = 'neo_rtd_theme'
+html_theme = 'sphinx_rtd_theme'
 html_theme_path = [sphinx_theme.get_html_theme_path()]
 html_logo = '_static/image.png'
 


### PR DESCRIPTION
Currently, prevent the search bar to run properly: https://github.com/mila-iqia/mila-docs/issues/66

This bug was reported in https://github.com/sphinx-doc/sphinx/issues/8623 , our current theme `neo_rtd_theme` is an old fork of `sphinx_rtd_theme` that has not being updated for the last 5 years.

Proposal is to switch to `sphinx_rtd_theme` which is one of the main supported theme for sphinx out there.

Demo: https://mila-docs-staging.readthedocs.io/en/latest/index.html
