### PR TITLE
Replace tmp1 with miniscratch

### DIFF
--- a/docs/Userguide_running_code.rst
+++ b/docs/Userguide_running_code.rst
@@ -388,12 +388,12 @@ Here is a ``sbatch`` script that follows good practices on the Mila cluster:
    :linenos:
 
    #!/bin/bash
-   #SBATCH --partition=unkillable                      # Ask for unkillable job
-   #SBATCH --cpus-per-task=2                     # Ask for 2 CPUs
-   #SBATCH --gres=gpu:1                          # Ask for 1 GPU
-   #SBATCH --mem=10G                             # Ask for 10 GB of RAM
-   #SBATCH --time=3:00:00                        # The job will run for 3 hours
-   #SBATCH -o /network/tmp1/<user>/slurm-%j.out  # Write the log on tmp1
+   #SBATCH --partition=unkillable                        # Ask for unkillable job
+   #SBATCH --cpus-per-task=2                             # Ask for 2 CPUs
+   #SBATCH --gres=gpu:1                                  # Ask for 1 GPU
+   #SBATCH --mem=10G                                     # Ask for 10 GB of RAM
+   #SBATCH --time=3:00:00                                # The job will run for 3 hours
+   #SBATCH -o /miniscratch/<u>/<username>/slurm-%j.out   # Write the log on scratch
 
    # 1. Load the required modules
    module --quiet load anaconda/3
@@ -409,4 +409,4 @@ Here is a ``sbatch`` script that follows good practices on the Mila cluster:
    python main.py --path $SLURM_TMPDIR --data_path $SLURM_TMPDIR
 
    # 5. Copy whatever you want to save on $SCRATCH
-   cp $SLURM_TMPDIR/<to_save> /network/tmp1/<user>/
+   cp $SLURM_TMPDIR/<to_save> /miniscratch/<u>/<username>/

--- a/docs/Userguide_singularity_on_clusters.rst
+++ b/docs/Userguide_singularity_on_clusters.rst
@@ -168,13 +168,14 @@ Mila cluster
 """"""""""""
 
 On the Mila cluster ``$SCRATCH`` is not yet defined, you should add the
-experiment results you want to keep in ``/network/tmp1/$USER/``.  In order to
-use the sbatch script above and to match other cluster environment's names, you
-can define ``$SCRATCH`` as an alias for ``/network/tmp1/$USER`` with:
+experiment results you want to keep in ``/miniscratch/<u>/<username>/``. In
+order to use the sbatch script above and to match other cluster environment's
+names, you can define ``$SCRATCH`` as an alias for
+``/miniscratch/<u>/<username>`` with:
 
 .. prompt:: bash $
 
-   echo "export SCRATCH=/network/tmp1/$USER" >> ~/.bashrc
+   echo "export SCRATCH=/miniscratch/${USER:0:1}/$USER" >> ~/.bashrc
 
 Then, you can follow the general procedure explained above.
 

--- a/docs/singularity/index.rst
+++ b/docs/singularity/index.rst
@@ -550,12 +550,15 @@ If you don't experience those problems with ``pyglet``, you probably don't need 
 Mila cluster
 """"""""""""
 
-On the Mila cluster ``$SCRATCH`` is not yet defined, you should add the experiment results you want to keep in ``/network/tmp1/$USER/``.
-In order to use the sbatch script above and to match other cluster environment's names, you can define ``$SCRATCH`` as an alias for ``/network/tmp1/$USER`` with:
+On the Mila cluster ``$SCRATCH`` is not yet defined, you should add the
+experiment results you want to keep in ``/miniscratch/<u>/<username>/``. In
+order to use the sbatch script above and to match other cluster environment's
+names, you can define ``$SCRATCH`` as an alias for
+``/miniscratch/<u>/<username>`` with:
 
 .. prompt:: bash $
 
-        echo "export SCRATCH=/network/tmp1/$USER" >> ~/.bashrc
+        echo "export SCRATCH=/miniscratch/${USER:0:1}/$USER" >> ~/.bashrc
 
 Then, you can follow the general procedure explained above.
 


### PR DESCRIPTION
`/network/tmp1` is not documented and should have been decommissioned a
while ago. Stop spreading the word about this soon-to-die file system.

Recommend `/miniscratch` instead since it is still the officially
supported scratch file system for the weeks to come.