### PR TITLE
Update information about username

### DIFF
--- a/docs/Getting_started.rst
+++ b/docs/Getting_started.rst
@@ -10,8 +10,9 @@ Getting started
 ===============
 
 **Before starting:** get your Mila cluster account ready. Typically, your
-username should look like the first six letters of your last name and the first
-letter of your first name, but this may vary.
+username is identical to your Mila account (the part before ``@mila.quebec``).
+In some special cases, it may look like the first seven letters of your last
+name and the first letter of your first name, but this may vary.
 
 
 Connect to the cluster


### PR DESCRIPTION
At the time of this commit, over 92% of our user base has their posixUid
identical to their Mila account in our directory database. Some historical
username are indeed made of shorten last name + first letter of first name,
thus it may be worthwhile to keep this information.