### PR TITLE
Update documentation with new scratch file system

### DIFF
--- a/docs/Information_sharing_policies.rst
+++ b/docs/Information_sharing_policies.rst
@@ -3,15 +3,9 @@ Data sharing policies
 
 .. _no_acl_note:
 
-.. note:: `/miniscratch <Information.html#storage>`_ aims to support Access
-   Control Lists (ACL) to allows collaborative work on rapidly changing data, e.g.
-   work in process datasets, model checkpoints, etc...
-
-
-   As of august 2021, licensing issues on our filesystem keeps us from
-   activating ACL functionalities. To benefit from sharing functionalities,
-   please contact the IT support who will configure the UNIX groups according to
-   your needs.
+.. note:: To benefit from sharing functionalities on ``/network/scratch``,
+   please contact the IT support who will configure the UNIX groups according
+   to your needs.
 
 
 `/network/projects <Information.html#storage>`_ aims to offer a collaborative

--- a/docs/Information_storage.rst
+++ b/docs/Information_storage.rst
@@ -15,11 +15,9 @@ Path                                        Performance Usage                   
                                                         * Long-term project storage
 ``/network/data1/``                         High        * Raw datasets (read only)
 ``/network/datasets/``                      High        * Curated raw datasets (read only)
-``/miniscratch/``                           High        * Temporary job results                                    90 days
+``/network/scratch/``                       High        * Temporary job results                                    90 days
                                                         * Processed datasets
                                                         * Optimized for small Files
-                                                        * Supports ACL to help share the
-                                                          data with others
 ``$SLURM_TMPDIR``                           Highest     * High speed disk for temporary job    4T/-                at job end
                                                           results
 =========================================== =========== ====================================== =================== ============
@@ -36,12 +34,10 @@ Path                                        Performance Usage                   
   <https://forms.gle/vDVwD2rZBmYHENgZA>`_.
 * ``data1`` should only contain **compressed** datasets. `Now deprecated and
   replaced by the` ``datasets`` `space.`
-* ``miniscratch`` can be used to store processed datasets, work in progress
+* ``scratch`` can be used to store processed datasets, work in progress
   datasets or temporary job results. Its block size is optimized for small
   files which minimizes the performance hit of working on extracted datasets.
-  It aims to support Access Control Lists (ACLs) which can be used to share data
-  between users. This space is cleared weekly and files older then 90 days will
-  be deleted. See :ref:`note on ACL availability above <no_acl_note>`.
+  This space is cleared weekly and files older then 90 days will be deleted.
 * ``$SLURM_TMPDIR`` points to the local disk of the node on which a job is
   running. It should be used to copy the data on the node at the beginning of
   the job and write intermediate checkpoints. This folder is cleared after each

--- a/docs/Userguide_datasets.rst
+++ b/docs/Userguide_datasets.rst
@@ -31,7 +31,7 @@ Mila hosts/seeds some datasets created by the Mila community through `Academic
 Torrent <https://academictorrents.com>`_. The first step is to create `an
 account and a torrent file <https://academictorrents.com/upload.php>`_.
 
-Then drop the dataset in ``/miniscratch/transit_datasets`` and send the
+Then drop the dataset in ``/network/scratch/.transit_datasets`` and send the
 Academic Torrent URL to `Mila's helpdesk <https://it-support.mila.quebec>`_. If
 the dataset does not reside on the Mila cluster, only the Academic Torrent URL
 would be needed to proceed with the initial download. Then you can delete /
@@ -50,12 +50,12 @@ Google Drive
 
 Only a member of the staff team can upload to `Mila's Google Drive
 <https://drive.google.com/drive/folders/1peJ6VF9wQ-LeETgcdGxu1e4fo28JbtUt>`_
-which requires to first drop the dataset in ``/miniscratch/transit_datasets``.
-Then, contact `Mila's helpdesk <https://it-support.mila.quebec>`_ and provide
-the following informations:
+which requires to first drop the dataset in
+``/network/scratch/.transit_datasets``. Then, contact `Mila's helpdesk
+<https://it-support.mila.quebec>`_ and provide the following informations:
 
 * directory containing the archived dataset (zip is favored) in
-  ``/miniscratch/transit_datasets``
+  ``/network/scratch/.transit_datasets``
 * the name of the dataset
 * a licence in ``.txt`` format. One of the `the creative common
   <https://creativecommons.org/about/cclicenses/>`_ licenses can be used. It is


### PR DESCRIPTION
The new scratch file system does not support ACLs without enterprise
license, thus I remove the information about ACLs. This could be added
back later if we should invest in enterprise level licenses.