### PR TITLE
Consistently use 'workload manager' when referring to the manager

### DIFF
--- a/docs/Extra_compute_cc.rst
+++ b/docs/Extra_compute_cc.rst
@@ -25,25 +25,27 @@ you are a student at University of Montreal, you can have access to the
 universities, you should ask your advisor to know which allocations you could
 have access to.
 
-From Compute Canada's documentation: `An allocation is an amount of resources
-that a research group can target for use for a period of time, usually a year.`
-To be clear, it is not a maximal amount of resources that can be used
-simultaneously, it is a weighting factor of the job scheduler to balance jobs.
-For instance, even though we are allocated 150 GPU-years on a cluster, we can
-use more or less than 150 GPUs simultaneously depending on the history of usage
-from our group and other groups using the cluster at a given period of time.
+From Compute Canada's documentation: `An allocation is an amount of
+resources that a research group can target for use for a period of
+time, usually a year.` To be clear, it is not a maximal amount of
+resources that can be used simultaneously, it is a weighting factor of
+the workload manager to balance jobs.  For instance, even though we
+are allocated 150 GPU-years on a cluster, we can use more or less than
+150 GPUs simultaneously depending on the history of usage from our
+group and other groups using the cluster at a given period of time.
 Please see Compute Canada's `documentation
-<https://docs.computecanada.ca/wiki/Allocations_and_resource_scheduling>`__ for
-more information on how allocations and resource scheduling are configured for
-these installations.
+<https://docs.computecanada.ca/wiki/Allocations_and_resource_scheduling>`__
+for more information on how allocations and resource scheduling are
+configured for these installations.
 
 .. Il est possiblement dangeureux de donner le nom de compte de Yoshua sur un
    site publiquement disponible.
 
-The table below provides information on the allocation for ``rrg-bengioy-ad`` for
-the period which spans from April 2021 to April 2022. Note that there are no
-special allocations for CPUs on Cedar and Graham and therefore jobs without GPUs
-should be submitted with the account ``def-bengioy``.
+The table below provides information on the allocation for
+``rrg-bengioy-ad`` for the period which spans from April 2021 to
+April 2022. Note that there are no special allocations for CPUs on
+Cedar and Graham and therefore jobs without GPUs should be submitted
+with the account ``def-bengioy``.
 
 
 +------------------------+-----------------------+--------------------------------------------------------+

--- a/docs/Theory_cluster_batch_scheduling.rst
+++ b/docs/Theory_cluster_batch_scheduling.rst
@@ -1,12 +1,13 @@
-The batch scheduler
-*******************
+The workload manager
+********************
 
-Once connected to a login node, presumably with SSH, you can issue a job
-execution request to what is called the job scheduler. The job scheduler used
-at Mila and Compute Canada clusters is called :ref:`Slurm <slurmpage>`.
-The job scheduler's main role is to find a place to run your program in what is
-simply called a *job*. This "place" is in fact one of many computers
-synchronised to the scheduler which are called :ref:`The compute nodes`.
+Once connected to a login node, presumably with SSH, you can issue a
+job execution request to what is called the workload manager. The
+workload manager used at Mila and Compute Canada clusters is called
+:ref:`Slurm <slurmpage>`.  The workload manager's main role is to find a
+place to run your program in what is simply called a *job*. This
+"place" is in fact one of many computers synchronised to the manager
+which are called :ref:`The compute nodes`.
 
 In fact it's a bit trickier than that, but we'll stay at this abstraction level
 for now.

--- a/docs/Theory_cluster_data.rst
+++ b/docs/Theory_cluster_data.rst
@@ -66,7 +66,7 @@ individual tasks can generally be scheduled indepandantly.
 
 On the contrary for model parallelism you need to pay more attention
 to where your tasks are.  In this case it is usually required to use
-the facilities of the job scheduler to group the tasks so that they
+the facilities of the workload manager to group the tasks so that they
 are on the same machine or machines that are closely linked to ensure
 optimal communication.  What is the best allocation depends on the
 specific cluster architecture available and the technologies it

--- a/docs/Theory_cluster_slurm.rst
+++ b/docs/Theory_cluster_slurm.rst
@@ -5,10 +5,11 @@
 Slurm
 =====
 
-Resource sharing on a supercomputer/cluster is orchestrated by a resource
-manager/job scheduler.  Users submit jobs, which are scheduled and allocated
-resources (CPU time, memory, GPUs, etc.) by the resource manager. If the
-resources are available the job can start otherwise it will be placed in queue.
+Resource sharing on a supercomputer/cluster is orchestrated by a
+workload manager. Users submit jobs, which are scheduled and allocated
+resources (CPU time, memory, GPUs, etc.) by the workload manager. If
+the resources are available the job can start otherwise it will be
+placed in queue.
 
 On a cluster, users don't have direct access to the compute nodes but instead
 connect to a login node to pass the commands they would like to execute in a


### PR DESCRIPTION
fixes #62 