### PR TITLE
Exclude login from SSH config block for computes

### DIFF
--- a/docs/Userguide_login.rst
+++ b/docs/Userguide_login.rst
@@ -142,7 +142,7 @@ If you wish, you may also add the following wildcard rule in your ``.ssh/config`
 
 .. code-block::
 
-    Host *.server.mila.quebec !*login.server.mila.quebe
+    Host *.server.mila.quebec !*login.server.mila.quebec
         HostName %h
         User YOUR-USERNAME
         ProxyJump mila

--- a/docs/Userguide_login.rst
+++ b/docs/Userguide_login.rst
@@ -142,7 +142,7 @@ If you wish, you may also add the following wildcard rule in your ``.ssh/config`
 
 .. code-block::
 
-    Host *.server.mila.quebec
+    Host *.server.mila.quebec !*login.server.mila.quebe
         HostName %h
         User YOUR-USERNAME
         ProxyJump mila


### PR DESCRIPTION
Without this rule, any attempt to connect to a specific login node with
login-X.login.server.mila.quebec will fail.