### PR TITLE
Small fix to ssh tunnelling instructions in Monitoring

### DIFF
--- a/docs/Information_monitoring.rst
+++ b/docs/Information_monitoring.rst
@@ -10,8 +10,10 @@ This information is exposed in two ways:
 
   * SSH tunnelling: on your local machine, run 
     
-    * ``ssh -L 19999:<node>.server.mila.quebec:19999 -p 2222 login.server.mila.quebec`` 
-    * or ``ssh -L 19999:<node>.server.mila.quebec:19999 mila`` if you have already setup your :ref:`SSH Login`,
+    * ``ssh -L 19999:<node>.server.mila.quebec:19999 -p 2222 
+      login.server.mila.quebec`` 
+    * or ``ssh -L 19999:<node>.server.mila.quebec:19999 mila`` if you have 
+      already setup your :ref:`SSH Login`,
   * then open http://localhost:19999 in your browser.
 * The Mila dashboard at `dashboard.server.mila.quebec <https://dashboard.server.mila.quebec/>`_
   exposes aggregated statistics with the use of `grafana <https://grafana.com/>`_.

--- a/docs/Information_monitoring.rst
+++ b/docs/Information_monitoring.rst
@@ -8,8 +8,11 @@ This information is exposed in two ways:
 * For every node, there is a web interface from Netdata itself at ``<node>.server.mila.quebec:19999``.
   This is accessible only when using the Mila wifi or through SSH tunnelling.
 
-  * SSH tunnelling: on your local machine, run ``ssh -L 19999:<node>.server.mila.quebec:19999 -p 2222 login.server.mila.quebec`` or ``ssh -L 19999:<node>.server.mila.quebec:19999`` if you have already setup your :ref:`SSH Login`,
-    then open http://localhost:19999 in your browser.
+  * SSH tunnelling: on your local machine, run 
+    
+    * ``ssh -L 19999:<node>.server.mila.quebec:19999 -p 2222 login.server.mila.quebec`` 
+    * or ``ssh -L 19999:<node>.server.mila.quebec:19999 mila`` if you have already setup your :ref:`SSH Login`,
+  * then open http://localhost:19999 in your browser.
 * The Mila dashboard at `dashboard.server.mila.quebec <https://dashboard.server.mila.quebec/>`_
   exposes aggregated statistics with the use of `grafana <https://grafana.com/>`_.
   These are collected internally to an instance of `prometheus <https://prometheus.io/>`_.

--- a/docs/Information_monitoring.rst
+++ b/docs/Information_monitoring.rst
@@ -8,7 +8,7 @@ This information is exposed in two ways:
 * For every node, there is a web interface from Netdata itself at ``<node>.server.mila.quebec:19999``.
   This is accessible only when using the Mila wifi or through SSH tunnelling.
 
-  * SSH tunnelling: on your local machine, run ``ssh -L19999:<node>.server.mila.quebec:19999 -p 2222 login.server.mila.quebec``,
+  * SSH tunnelling: on your local machine, run ``ssh -L 19999:<node>.server.mila.quebec:19999 -p 2222 login.server.mila.quebec`` or ``ssh -L 19999:<node>.server.mila.quebec:19999`` if you have already setup your :ref:`SSH Login`,
     then open http://localhost:19999 in your browser.
 * The Mila dashboard at `dashboard.server.mila.quebec <https://dashboard.server.mila.quebec/>`_
   exposes aggregated statistics with the use of `grafana <https://grafana.com/>`_.


### PR DESCRIPTION
add space between -L and port
add info about using `mila` and not specifying port if user has setup public key login