### PR TITLE
Instruction for monitoring individual GPU

### DIFF
--- a/docs/Information_monitoring.rst
+++ b/docs/Information_monitoring.rst
@@ -48,8 +48,6 @@ used in its full capacity.
 Given how expensive the GPUs are, it generally makes sense to try to
 make sure that this resources is always kept busy.
 
-.. TODO:: Vérifier que, effectivement, on peut regarder un GPU spécifique.
-
 * CPU
     * iowait (pink line): High values means your model is waiting on IO a lot (disk or network).
 
@@ -71,6 +69,7 @@ make sure that this resources is always kept busy.
 
 * GPU
     * Monitors the GPU usage using an `nvidia-smi plugin for Netdata <https://learn.netdata.cloud/docs/agent/collectors/python.d.plugin/nvidia_smi/>`_.
+    * Under the plugin interface, select the GPU number which was allocated to you. You can figure this out by running ``echo $SLURM_JOB_GPUS`` on the allocated node or, if you have the job ID, ``scontrol show -d job YOUR_JOB_ID | grep 'GRES'`` and looking for ``IDX``
     * You should make sure you use the GPUs to their fullest capacity.
     * Select the biggest batch size if possible to increase GPU memory usage and
       the GPU computational load.

--- a/docs/Information_monitoring.rst
+++ b/docs/Information_monitoring.rst
@@ -69,7 +69,10 @@ make sure that this resources is always kept busy.
 
 * GPU
     * Monitors the GPU usage using an `nvidia-smi plugin for Netdata <https://learn.netdata.cloud/docs/agent/collectors/python.d.plugin/nvidia_smi/>`_.
-    * Under the plugin interface, select the GPU number which was allocated to you. You can figure this out by running ``echo $SLURM_JOB_GPUS`` on the allocated node or, if you have the job ID, ``scontrol show -d job YOUR_JOB_ID | grep 'GRES'`` and looking for ``IDX``
+    * Under the plugin interface, select the GPU number which was allocated to
+      you. You can figure this out by running ``echo $SLURM_JOB_GPUS`` on the 
+      allocated node or, if you have the job ID, 
+      ``scontrol show -d job YOUR_JOB_ID | grep 'GRES'`` and checking ``IDX``
     * You should make sure you use the GPUs to their fullest capacity.
     * Select the biggest batch size if possible to increase GPU memory usage and
       the GPU computational load.


### PR DESCRIPTION
Add info for finding GPU number (e.g. `gpu3`) allocated to user by slurm (`SLURM_JOB_GPUS`)

Delete the TODO checking whether there is a way to monitor an individual GPU