### PR TITLE
Remove DSA fingerprint for login nodes

### DIFF
--- a/docs/Userguide_login.rst
+++ b/docs/Userguide_login.rst
@@ -34,12 +34,11 @@ You can access the Mila cluster via ssh:
 Four login nodes are available and accessible behind a load balancer. At each
 connection, you will be redirected to the least loaded login-node.
 
-The RSA, DSA and ECDSA fingerprints for Mila's login nodes are:
+The ECDSA, RSA and ED25519 fingerprints for Mila's login nodes are:
 
 .. code-block:: bash
 
     SHA256:baEGIa311fhnxBWsIZJ/zYhq2WfCttwyHRKzAb8zlp8 (ECDSA)
-    SHA256:XvukABPjV75guEgJX1rNxlDlaEg+IqQzUnPiGJ4VRMM (DSA)
     SHA256:Xr0/JqV/+5DNguPfiN5hb8rSG+nBAcfVCJoSyrR0W0o (RSA)
     SHA256:gfXZzaPiaYHcrPqzHvBi6v+BWRS/lXOS/zAjOKeoBJg (ED25519)
 


### PR DESCRIPTION
The login nodes do not use the DSA key anymore.