### PR TITLE
Clarification suggestion

### DIFF
--- a/docs/VSCode.rst
+++ b/docs/VSCode.rst
@@ -25,7 +25,7 @@ run:
 
 .. code-block:: bash
 
-    mila code path/to/code
+    mila code path/on/cluster
 
 Note that the above command requires your SSH config to be organized in a
 certain way, so you should run ``mila init`` prior to using ``mila code`` for


### PR DESCRIPTION
I misunderstood `path/to/code` to mean the path to the executable `code` on my local machine (like `$(which code)`).  Instead I see this is supposed to be a path on the cluster.  Edited to make unambiguous.