### PR TITLE
Replace Compute Canada with the Alliance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Here are some guidelines to help bring your contributions to life.
 ## What should be included in the Mila Docs
 
 * Mila cluster usage
-* Compute Canada cluster usage
+* Digital Research Alliance of Canada cluster usage
 * Job management tips / tricks
 * Research good practices
 * Software development good practices
@@ -49,11 +49,11 @@ This will produce the html version of the documentation which you can navigate
 by opening the local file `docs/_build/index.html`.
 
 If you have any trouble building the docs, don't hesitate to open an issue to
-request help. 
+request help.
 
-Regarding the restructured text format, you can simply provide the content 
-you would like to add in markdown or plain text format if more convenient 
-for you and someone down the line should take responsibility to convert 
+Regarding the restructured text format, you can simply provide the content
+you would like to add in markdown or plain text format if more convenient
+for you and someone down the line should take responsibility to convert
 the format.
 
 ## Sphinx / reStructuredText (reST)

--- a/docs/Extra_compute_drac.rst
+++ b/docs/Extra_compute_drac.rst
@@ -1,25 +1,26 @@
 .. highlight:: bash
-.. _cc_clusters:
+.. _drac_clusters:
 
 
-Compute Canada Clusters
-=======================
+Digital Research Alliance of Canada Clusters
+============================================
 
 The clusters named `Beluga`, `Cedar`, `Graham`, `Narval` and `Niagara` are
-clusters provided by the `Compute Canada organisation
-<https://alliancecan.ca/>`_. For Mila researchers, these clusters are to
-be used for larger experiments having many jobs, multi-node computation and/or
-multi-GPU jobs as well as long running jobs. If you use these resources for your
-research, please remember to `acknowledge their use in your papers
+clusters provided by the `Digital Research Alliance of Canada organisation
+<https://alliancecan.ca/>`_ (the Alliance). For Mila researchers, these
+clusters are to be used for larger experiments having many jobs, multi-node
+computation and/or multi-GPU jobs as well as long running jobs. If you use
+these resources for your research, please remember to `acknowledge their use in
+your papers
 <https://alliancecan.ca/en/services/advanced-research-computing/acknowledging-alliance>`_.
 
 
 Current allocation description
 ------------------------------
 
-Clusters of Compute Canada are shared with researchers across the country.
-Allocations are given by Compute Canada to selected research groups to ensure
-to a minimal amount of computational resources throughout the year.
+Clusters of the Alliance are shared with researchers across the country.
+Allocations are given by the Alliance to selected research groups to ensure to
+a minimal amount of computational resources throughout the year.
 
 Depending on your affiliation, you will have access to different allocations. If
 you are a student at University of Montreal, you can have access to the
@@ -27,18 +28,17 @@ you are a student at University of Montreal, you can have access to the
 universities, you should ask your advisor to know which allocations you could
 have access to.
 
-From Compute Canada's documentation: `An allocation is an amount of
-resources that a research group can target for use for a period of
-time, usually a year.` To be clear, it is not a maximal amount of
-resources that can be used simultaneously, it is a weighting factor of
-the workload manager to balance jobs.  For instance, even though we
-are allocated 400 GPU-years across all clusters, we can use more or less than
-400 GPUs simultaneously depending on the history of usage from our
-group and other groups using the cluster at a given period of time.
-Please see Compute Canada's `documentation
-<https://docs.computecanada.ca/wiki/Allocations_and_resource_scheduling>`__
-for more information on how allocations and resource scheduling are
-configured for these installations.
+From the Alliance's documentation: `An allocation is an amount of resources
+that a research group can target for use for a period of time, usually a year.`
+To be clear, it is not a maximal amount of resources that can be used
+simultaneously, it is a weighting factor of the workload manager to balance
+jobs. For instance, even though we are allocated 400 GPU-years across all
+clusters, we can use more or less than 400 GPUs simultaneously depending on the
+history of usage from our group and other groups using the cluster at a given
+period of time. Please see the Alliance's `documentation
+<https://docs.alliancecan.ca/wiki/Allocations_and_resource_scheduling>`__ for
+more information on how allocations and resource scheduling are configured for
+these installations.
 
 .. Il est possiblement dangeureux de donner le nom de compte de Yoshua sur un
    site publiquement disponible.
@@ -69,16 +69,16 @@ account ``def-bengioy``.
 Account Creation
 ----------------
 
-To access the Compute Canada (CC) clusters you have to first create an account
-at https://ccdb.computecanada.ca. Use a password with at least 8 characters,
-mixed case letters, digits and special characters. Later you will be asked to
-create another password with those rules, and it’s really convenient that the
-two password are the same.
+To access the Alliance clusters you have to first create an account at
+https://ccdb.computecanada.ca. Use a password with at least 8 characters, mixed
+case letters, digits and special characters. Later you will be asked to create
+another password with those rules, and it’s really convenient that the two
+password are the same.
 
 Then, you have to apply for a ``role`` at
-https://ccdb.computecanada.ca/me/add_role, which basically means telling CC that
-you are part of the lab so they know which cluster you can have access to, and
-track your usage.
+https://ccdb.computecanada.ca/me/add_role, which basically means telling the
+Alliance that you are part of the lab so they know which cluster you can have
+access to, and track your usage.
 
 You will be asked for the CCRI (See screenshot below). Please reach out to your
 sponsor to get the CCRI.
@@ -88,7 +88,7 @@ sponsor to get the CCRI.
     :alt: role.png
 
 You will need to **wait** for your sponsor to accept before being able to login
-to the CC clusters.
+to the Alliance clusters.
 
 
 Clusters
@@ -96,24 +96,24 @@ Clusters
 
 Beluga:
    (:ref:`Mila doc <beluga>`)
-   (`Compute Canada doc <https://docs.computecanada.ca/wiki/B%C3%A9luga/en>`__)
+   (`Digital Research Alliance of Canada doc <https://docs.alliancecan.ca/wiki/B%C3%A9luga/en>`__)
 
    For most students, Beluga is the best choice for both CPU and GPU jobs because
    of larger allocations on this cluster.
 Graham:
    (:ref:`Mila doc <graham>`)
-   (`Compute Canada doc <https://docs.computecanada.ca/wiki/Graham/en>`__)
+   (`Digital Research Alliance of Canada doc <https://docs.alliancecan.ca/wiki/Graham/en>`__)
 
    Graham has recent T4 GPUs. It can be a good alternative to Beluga with similar characteristics.
 Cedar:
    (:ref:`Mila doc <cedar>`)
-   (`Compute Canada doc <https://docs.computecanada.ca/wiki/Cedar/en>`__)
+   (`Digital Research Alliance of Canada doc <https://docs.alliancecan.ca/wiki/Cedar/en>`__)
 
    Cedar is a good alternative to Beluga if you absolutely need to have an internet connection
    on the compute nodes.
 Niagara:
    (:ref:`Mila doc <niagara>`)
-   (`Compute Canada doc <https://docs.computecanada.ca/wiki/Niagara/en>`__)
+   (`Digital Research Alliance of Canada doc <https://docs.alliancecan.ca/wiki/Niagara/en>`__)
 
    We do not have allocations on Niagara anymore but it remains a good alternative for CPU jobs.
 
@@ -123,8 +123,8 @@ Beluga
 
 Beluga is a cluster located at `ÉTS <https://www.etsmtl.ca/>`_ in Montreal. It
 uses SLURM to schedule jobs. Its full documentation can be found `here
-<https://docs.computecanada.ca/wiki/Béluga/en>`__, and its current status `here
-<http://status.computecanada.ca>`__.
+<https://docs.alliancecan.ca/wiki/B%C3%A9luga/en>`__, and its current status
+`here <http://status.alliancecan.ca>`__.
 
 You can access Beluga via ssh:
 
@@ -162,7 +162,7 @@ And to get an interactive session, use the ``salloc`` command:
     salloc --time=1:0:0 --account=rrg-bengioy-ad --gres=gpu:1
 
 The full documentation for jobs launching on Beluga can be found `here
-<https://docs.computecanada.ca/wiki/Running_jobs>`__.
+<https://docs.alliancecan.ca/wiki/Running_jobs>`__.
 
 
 Beluga nodes description
@@ -176,12 +176,12 @@ Each GPU node consists of:
 
 .. tip:: You should ask for max 10 CPU cores and 32 GB of RAM per GPU you are
    requesting (as explained `here
-   <https://docs.computecanada.ca/wiki/Allocations_and_resource_scheduling>`__),
+   <https://docs.alliancecan.ca/wiki/Allocations_and_resource_scheduling>`__),
    otherwise, your job will count for more than 1 allocation, and will take
    more time to get scheduled.
 
 
-.. _cc_storage:
+.. _drac_storage:
 
 
 Beluga Storage
@@ -222,7 +222,7 @@ When an experiment is finished, results should be transferred back to Mila
 servers.
 
 More details on storage can be found `here
-<https://docs.computecanada.ca/wiki/B%C3%A9luga/en#Storage>`__.
+<https://docs.alliancecan.ca/wiki/B%C3%A9luga/en#Storage>`__.
 
 
 Modules
@@ -231,7 +231,7 @@ Modules
 Many software, such as Python or MATLAB are already compiled and available on
 Beluga through the ``module`` command and its subcommands. Its full
 documentation can be found `here
-<https://docs.computecanada.ca/wiki/Utiliser_des_modules/en>`__.
+<https://docs.alliancecan.ca/wiki/Utiliser_des_modules/en>`__.
 
 ====================== =====================================
 module avail           Displays all the available modules
@@ -246,12 +246,13 @@ In particular, if you with to use ``Python 3.6`` you can simply do:
     module load python/3.6
 
 .. tip:: If you wish to use Python on the cluster, we strongly encourage you to
-   read `CC Python Documentation <https://docs.computecanada.ca/wiki/Python>`_,
-   and in particular the `Pytorch <https://docs.computecanada.ca/wiki/PyTorch>`_
-   and/or `Tensorflow <https://docs.computecanada.ca/wiki/TensorFlow>`_ pages.
+   read `Alliance Python Documentation
+   <https://docs.alliancecan.ca/wiki/Python>`_, and in particular the `Pytorch
+   <https://docs.alliancecan.ca/wiki/PyTorch>`_ and/or `Tensorflow
+   <https://docs.alliancecan.ca/wiki/TensorFlow>`_ pages.
 
 The cluster has many Python packages (or ``wheels``), such already compiled for
-the cluster. See `here <https://docs.computecanada.ca/wiki/Python/en>`__ for the
+the cluster. See `here <https://docs.alliancecan.ca/wiki/Python/en>`__ for the
 details. In particular, you can browse the packages by doing:
 
 .. prompt:: bash $
@@ -260,7 +261,7 @@ details. In particular, you can browse the packages by doing:
 
 Such wheels can be installed using pip. Moreover, the most efficient way to use
 modules on the cluster is to `build your environnement inside your job
-<https://docs.computecanada.ca/wiki/Python#Creating_virtual_environments_inside_of_your_jobs>`_.
+<https://docs.alliancecan.ca/wiki/Python#Creating_virtual_environments_inside_of_your_jobs>`_.
 See the script example below.
 
 
@@ -314,7 +315,7 @@ the necessary servers for using CometML and Wandb ("Weights and Biases").
     module load httpproxy
 
 More documentation about this can be found `here
-<https://docs.computecanada.ca/wiki/Weights_%26_Biases_(wandb)>`__.
+<https://docs.alliancecan.ca/wiki/Weights_%26_Biases_(wandb)>`__.
 
 
 Graham
@@ -322,8 +323,8 @@ Graham
 
 Graham is a cluster located at University of Waterloo. It uses SLURM to schedule
 jobs. Its full documentation can be found `here
-<https://docs.computecanada.ca/wiki/Graham/>`__, and its current status `here
-<http://status.computecanada.ca>`__.
+<https://docs.alliancecan.ca/wiki/Graham/>`__, and its current status `here
+<http://status.alliancecan.ca>`__.
 
 You can access Graham via ssh:
 
@@ -334,8 +335,8 @@ You can access Graham via ssh:
 Where ``<user>`` is the username you created previously (see `Account Creation`_).
 
 Since its structure is similar to `Beluga`, please look at the `Beluga`_
-documentation, as well as relevant parts of the `Compute Canada Documentation
-<https://docs.computecanada.ca/wiki/Graham>`__.
+documentation, as well as relevant parts of the `Digital Research Alliance of
+Canada Documentation <https://docs.alliancecan.ca/wiki/Graham>`__.
 
 .. note:: For GPU jobs the ressource allocation Group Name is the same as Beluga, so you should use the flag ``--account=rrg-bengioy-ad`` for GPU jobs.
 
@@ -345,8 +346,8 @@ Cedar
 
 Cedar is a cluster located at Simon Fraser University. It uses SLURM to schedule
 jobs. Its full documentation can be found `here
-<https://docs.computecanada.ca/wiki/Cedar>`__, and its current status `here
-<http://status.computecanada.ca>`__.
+<https://docs.alliancecan.ca/wiki/Cedar>`__, and its current status `here
+<http://status.alliancecan.ca>`__.
 
 You can access Cedar via ssh:
 
@@ -357,8 +358,8 @@ You can access Cedar via ssh:
 Where ``<user>`` is the username you created previously (see `Account Creation`_).
 
 Since its structure is similar to `Beluga`, please look at the `Beluga`_
-documentation, as well as relevant parts of the `Compute Canada Documentation
-<https://docs.computecanada.ca/wiki/Cedar>`__.
+documentation, as well as relevant parts of the `Digital Research Alliance of
+Canada Documentation <https://docs.alliancecan.ca/wiki/Cedar>`__.
 
 .. note:: However, we don't have any CPU priority on Cedar, in this case you can
   use ``--account=def-bengioy`` for CPU. Thus, it might take some time before
@@ -370,8 +371,8 @@ Niagara
 
 Niagara is a cluster located at University of Toronto. It uses SLURM to schedule
 jobs. Its full documentation can be found `here
-<https://docs.computecanada.ca/wiki/Niagara>`__, and its current status `here
-<http://status.computecanada.ca>`__.
+<https://docs.alliancecan.ca/wiki/Niagara>`__, and its current status `here
+<http://status.alliancecan.ca>`__.
 
 You can access Niagara via ssh:
 
@@ -382,8 +383,8 @@ You can access Niagara via ssh:
 Where ``<user>`` is the username you created previously (see `Account Creation`_).
 
 Since its structure is similar to `Beluga`, please look at the `Beluga`_
-documentation, as well as relevant parts of the `Compute Canada Documentation
-<https://docs.computecanada.ca/wiki/Niagara_Quickstart>`__.
+documentation, as well as relevant parts of the `Digital Research Alliance of
+Canada Documentation <https://docs.alliancecan.ca/wiki/Niagara_Quickstart>`__.
 
 
 FAQ
@@ -394,12 +395,12 @@ What to do with  `ImportError: /lib64/libm.so.6: version GLIBC_2.23 not found`?
 
 The structure of the file system is different than a classical Linux, so your
 code has trouble finding libraries. See `how to install binary packages
-<https://docs.computecanada.ca/wiki/Installing_software_in_your_home_directory#Installing_binary_packages>`_.
+<https://docs.alliancecan.ca/wiki/Installing_software_in_your_home_directory#Installing_binary_packages>`_.
 
 Disk quota exceeded error on ``/project`` file systems
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You have files in ``/project`` with the wrong permissions. See `how to change
 permissions
-<https://docs.computecanada.ca/wiki/Frequently_Asked_Questions/en#Disk_quota_exceeded_error_on_.2Fproject_filesystems>`_.
+<https://docs.alliancecan.ca/wiki/Frequently_Asked_Questions/en#Disk_quota_exceeded_error_on_.2Fproject_filesystems>`_.
 

--- a/docs/Information_data_transmission.rst
+++ b/docs/Information_data_transmission.rst
@@ -7,4 +7,4 @@ Multiple methods can be used to transfer data to/from the cluster:
 * ``rsync --bwlimit=10mb``; this is the favored method since the bandwidth can
   be limited to prevent impacting the usage of the cluster: `rsync
   <https://cl-cheat-sheet.readthedocs.io/en/latest/#rsync>`_
-* Compute Canada: `Globus <https://docs.computecanada.ca/wiki/Globus>`_
+* Digital Research Alliance of Canada: `Globus <https://docs.alliancecan.ca/wiki/Globus>`_

--- a/docs/Information_resources.rst
+++ b/docs/Information_resources.rst
@@ -6,24 +6,25 @@ number of jobs (< 5). It is a heterogeneous cluster. It uses
 :ref:`SLURM<slurmpage>` to schedule jobs.
 
 
-Mila cluster versus Compute Canada clusters
--------------------------------------------
+Mila cluster versus Digital Research Alliance of Canada clusters
+----------------------------------------------------------------
 
 There are a lot of commonalities between the Mila cluster and the clusters from
-Compute Canada (CC).  At the time being, the CC clusters where we have a large
-allocation of resources are `beluga`, `cedar` and `graham`.  We also have
-comparable computational resources in the Mila cluster, with more to come.
+Digital Research Alliance of Canada (the Alliance). At the time being, the
+Alliance clusters where we have a large allocation of resources are `beluga`,
+`cedar`, `graham` and `narval`. We also have comparable computational resources
+in the Mila cluster, with more to come.
 
 The main distinguishing factor is that we have more control over our own
-cluster than we have over the ones at Compute Canada.  Notably, also, the
-compute nodes in the Mila cluster all have unrestricted access to the Internet,
-which is not the case in general for CC clusters (although `cedar` does allow
-it).
+cluster than we have over the ones at the Alliance. Notably, also, the compute
+nodes in the Mila cluster all have unrestricted access to the Internet, which
+is not the case in general for the Alliance clusters (although `cedar` does
+allow it).
 
 At the current time of this writing (June 2021), Mila students are advised to
-use a healthy diet of a mix of Mila and CC clusters.  This is especially true
-in times when your favorite cluster is oversubscribed, because you can easily
-switch over to a different one if you are used to it.
+use a healthy diet of a mix of Mila and Alliance clusters. This is especially
+true in times when your favorite cluster is oversubscribed, because you can
+easily switch over to a different one if you are used to it.
 
 
 Guarantees about one GPU as absolute minimum
@@ -36,7 +37,7 @@ because it's a floor meaning that, at any time, you should be able to ask for
 your GPU, right now, and get it (although it might take a minute for the
 request to be processed by SLURM).
 
-Interactive sessions are possible on the CC clusters, and there are generally
-special rules that allow you to get resources more easily if you request them
-for a very short duration (for testing code before queueing long jobs).  You do
-not get the same guarantee as on the Mila cluster, however.
+Interactive sessions are possible on the Alliance clusters, and there are
+generally special rules that allow you to get resources more easily if you
+request them for a very short duration (for testing code before queueing long
+jobs). You do not get the same guarantee as on the Mila cluster, however.

--- a/docs/Theory_cluster_batch_scheduling.rst
+++ b/docs/Theory_cluster_batch_scheduling.rst
@@ -119,10 +119,10 @@ to ensure you estimate resource usage accurately.
 Mila information
 ----------------
 
-**Mila** as well as `Compute Canada
-<https://docs.computecanada.ca/wiki/Compute_Canada_Documentation>`_ use the
-workload manager `Slurm <https://slurm.schedmd.com/documentation.html>`_ to
-schedule and allocate resources on their infrastructure.
+**Mila** as well as `Digital Research Alliance of Canada
+<https://docs.alliancecan.ca/wiki/Technical_documentation>`_ use the workload
+manager `Slurm <https://slurm.schedmd.com/documentation.html>`_ to schedule and
+allocate resources on their infrastructure.
 
 **Slurm** client commands are available on the login nodes for you to submit
 jobs to the main controller and add your job to the queue. Jobs are of 2 types:

--- a/docs/Theory_cluster_data.rst
+++ b/docs/Theory_cluster_data.rst
@@ -89,9 +89,9 @@ slow write performance. This is because datasets are usually written
 once and then read very often for training.
 
 Different filesystems have different performance levels. For instance, backed
-up filesystems (such as ``$PROJECT`` in Compute Canada clusters) provide more
-space and can handle large files but cannot sustain highly parallel accesses
-typically required for high speed model training.
+up filesystems (such as ``$PROJECT`` in Digital Research Alliance of Canada
+clusters) provide more space and can handle large files but cannot sustain
+highly parallel accesses typically required for high speed model training.
 
 The set of filesystems provided by the cluster you are using should be
 detailed in the documentation for that cluster and the names can

--- a/docs/Theory_cluster_software_deps.rst
+++ b/docs/Theory_cluster_software_deps.rst
@@ -5,10 +5,10 @@ This section aims to raise awareness to problems one can encounter when trying
 to run a software on different computers and how this is dealt with on typical
 computation clusters.
 
-The Mila cluster and the Compute Canada cluster both provide various useful
-software and computing environments, which can be activated through the module
-system. Alternatively, you may build containers with your desired software and
-run them on compute nodes.
+The Mila cluster and the Digital Research Alliance of Canada clusters both
+provide various useful software and computing environments, which can be
+activated through the module system. Alternatively, you may build containers
+with your desired software and run them on compute nodes.
 
 Regarding Python development, we recommend using virtual environments to install
 Python packages in isolation.

--- a/docs/Theory_cluster_unix.rst
+++ b/docs/Theory_cluster_unix.rst
@@ -3,6 +3,6 @@ UNIX
 
 All clusters typically run on GNU/Linux distributions. Hence a minimum
 knowledge of GNU/Linux and BASH is usually required to use them. See the
-following `tutorial <https://docs.computecanada.ca/wiki/Linux_introduction>`_
+following `tutorial <https://docs.alliancecan.ca/wiki/Linux_introduction>`_
 for a rough guide on getting started with Linux.
 

--- a/docs/Userguide_data_transfer.rst
+++ b/docs/Userguide_data_transfer.rst
@@ -3,9 +3,10 @@ Data Transmission using Globus Connect Personal
 
 
 Mila doesn't own a Globus license but if the source or destination provides a
-Globus account, like Compute Canada for example, it's possible to setup Globus
-Connect Personal to create a personal endpoint on the Mila cluster by following
-the Globus guide to `Install, Configure, and Uninstall Globus Connect Personal
-for Linux <https://docs.globus.org/how-to/globus-connect-personal-linux/>`_.
+Globus account, like Digital Research Alliance of Canada for example, it's
+possible to setup Globus Connect Personal to create a personal endpoint on the
+Mila cluster by following the Globus guide to `Install, Configure, and
+Uninstall Globus Connect Personal for Linux
+<https://docs.globus.org/how-to/globus-connect-personal-linux/>`_.
 
 This endpoint can then be used to transfer data to and from the Mila cluster.

--- a/docs/Userguide_datasets.rst
+++ b/docs/Userguide_datasets.rst
@@ -7,9 +7,9 @@ If a dataset could help the research of others at Mila, `this form
 to `/network/datasets <Information.html#storage>`_.
 
 Those datasets can be mirrored to the Béluga cluster in
-``~/projects/rrg-bengioy-ad/data/curated/`` if they follow Compute Canada's
-`good practices on data
-<https://docs.computecanada.ca/wiki/AI_and_Machine_Learning#Managing_your_datasets>`_.
+``~/projects/rrg-bengioy-ad/data/curated/`` if they follow Digital Research
+Alliance of Canada's `good practices on data
+<https://docs.alliancecan.ca/wiki/AI_and_Machine_Learning#Managing_your_datasets>`_.
 
 
 Publicly share a Mila dataset

--- a/docs/Userguide_jupyterhub.rst
+++ b/docs/Userguide_jupyterhub.rst
@@ -7,13 +7,14 @@ session as a batch job then connects it when the allocation has been granted.
 It does not require any ssh tunnel or port redirection, the hub acts as a proxy
 server that will redirect you to a session as soon as it is available.
 
-It is currently available for Mila clusters and some Compute Canada clusters
+It is currently available for Mila clusters and some Digital Research Alliance
+of Canada (Alliance) clusters.
 
 ============== ============================================= ============
 Cluster        Address                                       Login type
 ============== ============================================= ============
 Mila Local     https://jupyterhub.server.mila.quebec         Google Oauth
-Compute Canada https://docs.computecanada.ca/wiki/JupyterHub CC login
+Alliance       https://docs.alliancecan.ca/wiki/JupyterHub   DRAC login
 ============== ============================================= ============
 
 .. warning:: Do not forget to close the JupyterLab session! Closing the window leaves

--- a/docs/Userguide_multigpu.rst
+++ b/docs/Userguide_multigpu.rst
@@ -99,9 +99,9 @@ Or by specifying a range of tasks
 Sharing a node with multiple GPU 1process/GPU
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-On Compute Canada, several nodes, especially nodes with ``largeGPU`` (P100) are
-reserved for jobs requesting the whole node, therefore packing multiple
-processes in a single job can leverage faster GPU.
+On Digital Research Alliance of Canada, several nodes, especially nodes with
+``largeGPU`` (P100) are reserved for jobs requesting the whole node, therefore
+packing multiple processes in a single job can leverage faster GPU.
 
 If you want different tasks to access different GPUs in a single allocation you
 need to create an allocation requesting a whole node and using ``srun`` with a

--- a/docs/Userguide_portability.rst
+++ b/docs/Userguide_portability.rst
@@ -59,7 +59,7 @@ Another option for creating portable code is :ref:`Using containers`.
 Containers are a popular approach at deploying applications by packaging a lot
 of the required dependencies together. The most popular tool for this is
 `Docker <https://www.docker.com/>`_, but Docker cannot be used on the Mila
-cluster (nor the other clusters from Compute Canada).
+cluster (nor the other clusters from Digital Research Alliance of Canada).
 
 One popular mechanism for containerisation on a computational cluster is called
 `Singularity <https://singularity-docs.readthedocs.io/en/latest/>`_.

--- a/docs/Userguide_python.rst
+++ b/docs/Userguide_python.rst
@@ -27,8 +27,8 @@ Pip is the preferred package manager for Python and each cluster provides
 several Python versions through the associated module which comes with pip. In
 order to install new packages, you will first have to create a personal space
 for them to be stored.  The preferred solution (as it is the preferred solution
-on Compute Canada clusters) is to use `virtual environments
-<https://virtualenv.pypa.io/en/stable/>`_.
+on Digital Research Alliance of Canada clusters) is to use `virtual
+environments <https://virtualenv.pypa.io/en/stable/>`_.
 
 First, load the Python module you want to use:
 
@@ -68,8 +68,8 @@ Conda
 Another solution for Python is to use `miniconda
 <https://docs.conda.io/en/latest/miniconda.html>`_ or `anaconda
 <https://docs.anaconda.com>`_ which are also available through the ``module``
-command: (the use of Conda is not recommended for Compute Canada Clusters due to
-the availability of custom-built packages for pip)
+command: (the use of Conda is not recommended for Digital Research Alliance of
+Canada clusters due to the availability of custom-built packages for pip)
 
 .. prompt:: bash $, auto
 

--- a/docs/Userguide_singularity_on_clusters.rst
+++ b/docs/Userguide_singularity_on_clusters.rst
@@ -181,12 +181,12 @@ Then, you can follow the general procedure explained above.
 
 
 
-Compute Canada
-""""""""""""""
+Digital Research Alliance of Canada
+"""""""""""""""""""""""""""""""""""
 
-Using singularity on Compute Canada is similar except that you need to add
-Yoshua's account name and load singularity.  Here is an example of a ``sbatch``
-script using singularity on compute Canada cluster:
+Using singularity on Digital Research Alliance of Canada is similar except that
+you need to add Yoshua's account name and load singularity. Here is an example
+of a ``sbatch`` script using singularity on compute Canada cluster:
 
 .. warning:: You should use singularity/2.6 or singularity/3.4. There is a bug
    in singularity/3.2 which makes gpu unusable.

--- a/docs/singularity/index.rst
+++ b/docs/singularity/index.rst
@@ -564,11 +564,12 @@ Then, you can follow the general procedure explained above.
 
 
 
-Compute Canada
-""""""""""""""
+Digital Research Alliance of Canada
+"""""""""""""""""""""""""""""""""""
 
-Using singularity on Compute Canada is similar except that you need to add Yoshua's account name and load singularity.
-Here is an example of a ``sbatch`` script using singularity on compute Canada cluster:
+Using singularity on Digital Research Alliance of Canada is similar except that
+you need to add Yoshua's account name and load singularity.  Here is an example
+of a ``sbatch`` script using singularity on compute Canada cluster:
 
 .. warning:: You should use singularity/2.6 or singularity/3.4. There is a bug in singularity/3.2 which makes gpu unusable.
 


### PR DESCRIPTION
Compute Canada was replaced by the Digital Research Alliance of Canada. Update the documentation as well as the URL to the new documentation website.

Some resources still use the computecanada.ca domain: CCDB and login nodes.

Also remove CRLF from CONTRIBUTING.md.

Closes: #132 