### PR TITLE
Use python 3.8 instead of 3.9 in the examples

### DIFF
--- a/docs/Userguide_python.rst
+++ b/docs/Userguide_python.rst
@@ -34,13 +34,13 @@ First, load the Python module you want to use:
 
 .. prompt:: bash $
 
-   module load python/3.9
+   module load python/3.8
 
 Then, create a virtual environment in your ``home`` directory:
 
 .. prompt:: bash $
 
-   virtualenv $HOME/<env>
+   python -m venv $HOME/<env>
 
 Where ``<env>`` is the name of your environment. Finally, activate the environment:
 


### PR DESCRIPTION
Our Lmod module `python/3.9.5` is currently broken, avoid recommending it in the examples (ref: FD ticket# 10328)