### PR TITLE
Add "Minimal Examples" section with a PyTorch Setup example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 _build
 .idea
+**/__pycache__

--- a/docs/Minimal_examples.rst
+++ b/docs/Minimal_examples.rst
@@ -1,0 +1,6 @@
+.. ***************************
+.. Minimal Examples
+.. ***************************
+
+
+.. include:: examples/frameworks/README.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,8 @@ exclude_patterns = ['_build',
                     'Purpose_*',
                     'Extra_compute_*',
                     'IDT_*',
-                    'singularity/*']
+                    'singularity/*',
+                    'examples/*',]
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 

--- a/docs/examples/frameworks/README.rst
+++ b/docs/examples/frameworks/README.rst
@@ -1,0 +1,7 @@
+*******************
+Software Frameworks
+*******************
+
+
+
+.. include:: examples/frameworks/pytorch_setup/README.rst

--- a/docs/examples/frameworks/README.rst
+++ b/docs/examples/frameworks/README.rst
@@ -3,5 +3,4 @@ Software Frameworks
 *******************
 
 
-
 .. include:: examples/frameworks/pytorch_setup/README.rst

--- a/docs/examples/frameworks/pytorch_setup/README.rst
+++ b/docs/examples/frameworks/pytorch_setup/README.rst
@@ -1,0 +1,33 @@
+PyTorch Setup
+===================
+
+.. IDEA: Add a link to all the sections of the documentation that have to
+.. absolutely have been read before this tutorial.
+
+**Prerequisites**: (Make sure to read the following before using this example!)
+
+* :ref:`Quick Start`
+* :ref:`Running your code`
+* :ref:`Conda`
+
+
+**job.sh**
+
+
+.. literalinclude:: /examples/frameworks/pytorch_setup/job.sh
+    :language: bash
+
+
+**main.py**
+
+
+.. literalinclude:: /examples/frameworks/pytorch_setup/main.py
+    :language: python
+
+
+**Running this example**
+
+
+.. code-block:: bash
+
+    $ sbatch job.sh

--- a/docs/examples/frameworks/pytorch_setup/job.sh
+++ b/docs/examples/frameworks/pytorch_setup/job.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=16G
+#SBATCH --time=00:15:00
+#SBATCH --partition=unkillable
+
+set -e  # exit on error.
+echo "Date:     $(date)"
+echo "Hostname: $(hostname)"
+
+module purge
+# This example uses Conda to manage package dependencies.
+# See https://docs.mila.quebec/Userguide.html#conda for more information.
+module load anaconda/3
+
+# Creating the environment for the first time:
+# conda create -y -n pytorch python=3.9 pytorch torchvision torchaudio \
+#     pytorch-cuda=11.6 -c pytorch -c nvidia
+
+# Activate the environment:
+conda activate pytorch
+
+python main.py

--- a/docs/examples/frameworks/pytorch_setup/main.py
+++ b/docs/examples/frameworks/pytorch_setup/main.py
@@ -1,0 +1,21 @@
+import torch
+import torch.backends.cuda
+
+
+def main():
+    cuda_built = torch.backends.cuda.is_built()
+    cuda_avail = torch.cuda.is_available()
+    device_count = torch.cuda.device_count()
+
+    print(f"PyTorch built with CUDA:         {cuda_built}")
+    print(f"PyTorch detects CUDA available:  {cuda_avail}")
+    print(f"PyTorch-detected #GPUs:          {device_count}")
+    if device_count == 0:
+        print("    No GPU detected, not printing devices' names.")
+    else:
+        for i in range(device_count):
+            print(f"    GPU {i}:      {torch.cuda.get_device_name(i)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,13 @@ recommend you start by checking out the :ref:`short quick start guide
 
    Theory_cluster
 
+
+.. toctree::
+   :caption: Minimal Examples
+   :maxdepth: 2
+
+   Minimal_examples
+
 .. toctree::
    :caption: Extras
    :maxdepth: 2
@@ -53,4 +60,3 @@ recommend you start by checking out the :ref:`short quick start guide
    sections, or would simply like to contribute, please open an
    issue or make a pull request on the `github page
    <https://github.com/mila-iqia/mila-docs>`_.
-


### PR DESCRIPTION
WIP: Adding a new section with minimal examples.

Each example will contain the following:

- A list of **prerequisites**: Sections of the documentation that have to be read before using the example
- An sbatch script (`job.sh`)
- A Python script (`main.py`)
- A `README.rst` file, refered to in the documentation.

TODOs:
- [x] Remove the duplicated content from #151.
- [x] Add a "Running this example" section for each example.
- [x] Fix the "multiple labels X" (where X="prerequisites" or "Running this example") issue with the .rst files, 