### PR TITLE
fix: test the Build The Docs workflow

### DIFF
--- a/.github/workflows/btd_test.yml
+++ b/.github/workflows/btd_test.yml
@@ -1,0 +1,23 @@
+---
+name: build_the_docs_test
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  btd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: buildthedocs/btd@v0
+        with:
+          token: ${{ github.token }}
+          skip-deploy: true
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: docs
+          path: docs/_build/html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,18 +91,5 @@ html_context = {
 # Include CNAME file so GitHub Pages can set Custom Domain name
 html_extra_path = ['CNAME']
 
-
-# Generate the diffs that are shown in the examples.
-file_dir = Path(__file__).parent / "examples/generate_diffs.sh"
-try:
-    proc = subprocess.run(str(file_dir), shell=True, capture_output=True, check=True)
-except subprocess.CalledProcessError as err:
-    raise RuntimeError(
-        "Could not build the diff files for the examples:\n"
-        + str(err.output, encoding="utf-8")
-        + str(err.stderr, encoding="utf-8")
-    )
-
-
 def setup(app):
     app.add_css_file('custom.css')


### PR DESCRIPTION
Add a new test to run the GitHub action that executes build the docs for any pull request on `master`.

Also add a workaround to fix #183.