### PR TITLE
Revert "fix: avoid sphinx-rtd-theme 1.2.0"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,5 +9,5 @@ myst-parser>=0.14.0
 sphinx-theme>=1.0
 sphinx-copybutton>=0.3.1
 sphinx-prompt>=1.4.0
-sphinx-rtd-theme>=0.5.2,<1.2.0
+sphinx-rtd-theme>=0.5.2
 sphinx-readable-theme


### PR DESCRIPTION
This reverts commit 7dd947e806ea0a725f66baa3cbb5fe4f36347f64.