### PR TITLE
added page for chatbot page

### DIFF
--- a/docs/Chatbot.rst
+++ b/docs/Chatbot.rst
@@ -1,0 +1,16 @@
+Chatbot for Mila
+****************
+
+The Mila Documentation chatbot is currently accessible at `https://mila-docs-chatbot-dev.herokuapp.com <https://mila-docs-chatbot-dev.herokuapp.com>`_.
+This requires a username/password that can be found `here <https://docs.google.com/document/d/1QLx39aiBJIbGIrdhu5GeRwG8fKauvGok8D7CQiB4kEM/edit?usp=sharing>`_.
+
+It will later require authentication through your @mila.quebec account, but not at the moment.
+
+**All submitted questions are logged anonymously**. We will review the usage that people do, but we are not keeping track of who is asking which questions.
+
+All the queries use OpenAI GPT 3.5, which incurs negligible usage costs for Mila (0.002$ per 1k tokens). There is an automatic cutoff limit to our budget, but feel free to use it as much as needed for the time being. It would be a triumph if we reached a point where we actually spent $40 to answer useful questions.
+
+This chatbot is based on the work by Jeremy Pinto and Hadrien Bertrand.
+It currently indexes data from here at `docs.mila.quebec <docs.mila.quebec>`_,
+but it will soon be extended to other sources of information.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,6 +54,7 @@ recommend you start by checking out the :ref:`short quick start guide
    Audio_video
    VSCode
    IDT
+   Chatbot
 
 :Support: To reach the Mila infrastructure support, please `submit
    a support ticket. <https://milaquebec.freshdesk.com/a/tickets/new>`_


### PR DESCRIPTION
For https://mila-iqia.atlassian.net/browse/DOC-114.

Adding a link for the Chatbot from Jeremy and Hadrien (protected by a password found in a google docs).

Looking for comments in case someone thinks that I put the link in the wrong place. Test the procedure for yourself to see if you can access it.