### PR TITLE
Update sbatch example to require GPUs with 48GB

### DIFF
--- a/docs/Userguide_running_code.rst
+++ b/docs/Userguide_running_code.rst
@@ -381,11 +381,11 @@ Specific GPU *architecture* and *memory* can be easily requested through the
 
 *Example:*
 
-To request 1 GPU with *at least* 16GB of memory use
+To request 1 GPU with *at least* 48GB of memory use
 
 .. prompt:: bash $
 
-    sbatch -c 4 --gres=gpu:16gb:1
+    sbatch -c 4 --gres=gpu:48gb:1
 
 The full list of GPU and their features can be accessed :ref:`here <node_list>`.
 


### PR DESCRIPTION
The last node with 16GB GPUs is kepler5 that may be removed soon.