### PR TITLE
load anaconda

### DIFF
--- a/docs/examples/frameworks/pytorch_setup/README.rst
+++ b/docs/examples/frameworks/pytorch_setup/README.rst
@@ -104,6 +104,8 @@ support, and to have all the required libraries.
     salloc: Granted job allocation 2959785
     salloc: Waiting for resource configuration
     salloc: Nodes cn-g022 are ready for job
+    $ # Load anaconda
+    $ module load anaconda/3
     $ # Create the environment (see the example):
     $ conda create -n pytorch python=3.9 pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch -c nvidia
     (...)

--- a/docs/examples/frameworks/pytorch_setup/index.rst
+++ b/docs/examples/frameworks/pytorch_setup/index.rst
@@ -50,6 +50,8 @@ support, and to have all the required libraries.
     salloc: Granted job allocation 2959785
     salloc: Waiting for resource configuration
     salloc: Nodes cn-g022 are ready for job
+    $ # Load anaconda
+    $ module load anaconda/3
     $ # Create the environment (see the example):
     $ conda create -n pytorch python=3.9 pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch -c nvidia
     (...)


### PR DESCRIPTION
Loading anaconda added to environment creation instructions. I also would think it may be preferable to name the environment something besides 'pytorch'. Something more unique like 'pytorch_ex'. 
I didn't  change that though. Also, maybe the python version could be updated somewhat (though this could lead to changes in other parts of examples).