### PR TITLE
errata and email

### DIFF
--- a/docs/Cheatsheet.rst
+++ b/docs/Cheatsheet.rst
@@ -36,11 +36,10 @@ The jobs from the `long` partition can be preempted to allow jobs in the `main` 
 but jobs in `main` are never going to be preempted to allow for other jobs in `main`, no matter how much
 of the "fair use" a user has already consumed.
 
-This is why it can be considered rude (or just bad practice) to queue a large number of jobs
-on `main` at midnight on the Mila cluster with a lot of free capacity.
-On the next day, those jobs might still be running and much of the compute capacity
-will be shared very unequally between the users, even though it seemed like a good strategy
-to schedule jobs when the cluster was idle.
+Jobs for the `unkillable` partition can preempt everything except other jobs on the `unkillable` partition.
+
+A good explanation of priorities and preemption will be added to the documentation,
+but the cheat sheet (or the cheat sheet errata) is not the place for this.
 
 Default accounts on DRAC oversimplified
 ---------------------------------------

--- a/docs/Cheatsheet.rst
+++ b/docs/Cheatsheet.rst
@@ -19,8 +19,43 @@ which is the original source of information.
 Moreover, the official documentation is updated regularly, whereas the cheat sheet
 is probably going to be updated once a year (around April when the new DRAC allocations are announced).
 
+Comments and suggestions are welcome (`idt.cheatsheet@mila.quebec`).
+Please also signal errors if you spot them before we do.
+
+
 Errata
 ======
 
 Here is a list of the known errors in the cheat sheet that will have to be fixed in the next version.
 
+Partition preemption is not explained accurately on page 2
+----------------------------------------------------------
+
+The preemption on the Mila cluster is a bit more complicated than what is described in the cheat sheet.
+The jobs from the `long` partition can be preempted to allow jobs in the `main` partition to run,
+but jobs in `main` are never going to be preempted to allow for other jobs in `main`, no matter how much
+of the "fair use" a user has already consumed.
+
+This is why it can be considered rude (or just bad practice) to queue a large number of jobs
+on `main` at midnight on the Mila cluster with a lot of free capacity.
+On the next day, those jobs might still be running and much of the compute capacity
+will be shared very unequally between the users, even though it seemed like a good strategy
+to schedule jobs when the cluster was idle.
+
+Default accounts on DRAC oversimplified
+---------------------------------------
+
+Technically, any professor can "sponsor" a user so that they have access to their "def-theirprofname" account.
+It could be another professor besides the one supervising a given student,
+even though it is not common practice (a notable exception being "def-bengioy").
+A professor could even sponsor a student that is not affiliated with Mila in any way
+for them to use the default account of that professor.
+
+The cheat sheet implied that this was something that was more "automatic",
+whereby every student has already access to the "def-theirprofname" account.
+
+
+Minor typos
+-----------
+
+"Ask for things that are easy to schedule, the scheduler will be much nicer to you." -> Missing the word "and".

--- a/docs/Cheatsheet.rst
+++ b/docs/Cheatsheet.rst
@@ -59,3 +59,4 @@ Minor typos
 -----------
 
 "Ask for things that are easy to schedule, the scheduler will be much nicer to you." -> Missing the word "and".
+


### PR DESCRIPTION
I'd added the email for the mailing group `idt.cheatsheet@mila.quebec`, which was tested and works as expected.

I've added some information in the errata section because, after talking with Bruno and Olexa, I realized that I wasn't describing preemption accurately. In fact, I was make wrong statements. I don't need to explain everything on the cheat sheet, but I least I don't want to suggest incorrect interpretations.

I've added some clarification about who has access to the "default" accounts for professors. Again, the cheat sheet was oversimplifying things in a way that could lead to incorrect interpretations.

Adding a reference to a typo also.