### PR TITLE
Add 20TB quota on scratch

### DIFF
--- a/docs/Information_storage.rst
+++ b/docs/Information_storage.rst
@@ -12,7 +12,7 @@ Path                                                   Performance Usage        
 ``/network/weights/``                                  High        * Curated models weights (read only)
 ``$HOME`` or ``/home/mila/<u>/<username>/``            Low         * Personal user space                  100GB/1000K         Daily  no
                                                                    * Specific libraries, code, binaries
-``$SCRATCH`` or ``/network/scratch/<u>/<username>/``   High        * Temporary job results                no                  no     90 days
+``$SCRATCH`` or ``/network/scratch/<u>/<username>/``   High        * Temporary job results                20TB/no             no     90 days
                                                                    * Processed datasets
                                                                    * Optimized for small Files
 ``$SLURM_TMPDIR``                                      Highest     * High speed disk for temporary job    4TB/-               no     at job end


### PR DESCRIPTION
The quota of 20TB was added to prevent recurring abuse of the file system.