### PR TITLE
Bugfix GPU ordinal computation

### DIFF
--- a/docs/examples/distributed/multi_gpu/README.rst
+++ b/docs/examples/distributed/multi_gpu/README.rst
@@ -29,6 +29,7 @@ Click here to see `the code for this example
     #SBATCH --cpus-per-task=4
    -#SBATCH --ntasks-per-node=1
    +#SBATCH --ntasks-per-node=4
+   +#SBATCH --nodes=1
     #SBATCH --mem=16G
     #SBATCH --time=00:15:00
 
@@ -121,7 +122,7 @@ Click here to see `the code for this example
    -    device = torch.device("cuda", 0)
    +    rank, world_size = setup()
    +    is_master = rank == 0
-   +    device = torch.device("cuda", rank)
+   +    device = torch.device("cuda", rank % torch.cuda.device_count())
 
         # Setup logging (optional, but much better than using print statements)
         logging.basicConfig(

--- a/docs/examples/distributed/multi_gpu/job.sh
+++ b/docs/examples/distributed/multi_gpu/job.sh
@@ -2,6 +2,7 @@
 #SBATCH --gpus-per-task=rtx8000:1
 #SBATCH --cpus-per-task=4
 #SBATCH --ntasks-per-node=4
+#SBATCH --nodes=1
 #SBATCH --mem=16G
 #SBATCH --time=00:15:00
 

--- a/docs/examples/distributed/multi_gpu/main.py
+++ b/docs/examples/distributed/multi_gpu/main.py
@@ -37,7 +37,7 @@ def main():
     assert torch.cuda.is_available() and torch.cuda.device_count() > 0
     rank, world_size = setup()
     is_master = rank == 0
-    device = torch.device("cuda", rank)
+    device = torch.device("cuda", rank % torch.cuda.device_count())
 
     # Setup logging (optional, but much better than using print statements)
     logging.basicConfig(

--- a/docs/examples/distributed/multi_node/README.rst
+++ b/docs/examples/distributed/multi_node/README.rst
@@ -30,6 +30,7 @@ Click here to see `the source code for this example
     #SBATCH --gpus-per-task=rtx8000:1
     #SBATCH --cpus-per-task=4
     #SBATCH --ntasks-per-node=4
+   -#SBATCH --nodes=1
    +#SBATCH --nodes=2
     #SBATCH --mem=16G
     #SBATCH --time=00:15:00
@@ -121,9 +122,9 @@ Click here to see `the source code for this example
    -    rank, world_size = setup()
    +    rank, world_size, local_rank = setup()
         is_master = rank == 0
-   -    device = torch.device("cuda", rank)
+   -    device = torch.device("cuda", rank % torch.cuda.device_count())
    +    is_local_master = local_rank == 0
-   +    device = torch.device("cuda", local_rank)
+   +    device = torch.device("cuda", local_rank % torch.cuda.device_count())
 
         # Setup logging (optional, but much better than using print statements)
         logging.basicConfig(

--- a/docs/examples/distributed/multi_node/main.py
+++ b/docs/examples/distributed/multi_node/main.py
@@ -39,7 +39,7 @@ def main():
     rank, world_size, local_rank = setup()
     is_master = rank == 0
     is_local_master = local_rank == 0
-    device = torch.device("cuda", local_rank)
+    device = torch.device("cuda", local_rank % torch.cuda.device_count())
 
     # Setup logging (optional, but much better than using print statements)
     logging.basicConfig(


### PR DESCRIPTION
With `--gpus-per-task=rtx8000:1`, all tasks only see `1` GPU. Therefore, the only valid GPU ordinal is `0`, even if each task sees a different single GPU.

For extra robustness, use the common trick of calculating the ordinal as `ordinal = rank % device_count()`, which works both in and outside of SLURM.