### PR TITLE
Change `conda clean --all` to `-it`

### DIFF
--- a/docs/Userguide_python.rst
+++ b/docs/Userguide_python.rst
@@ -104,7 +104,7 @@ can be good to periodically clean up Conda's cache:
 
 .. prompt:: bash (<env>)$
 
-   conda clean --all
+   conda clean -it
 
 **Mamba**
 


### PR DESCRIPTION
Due to legacy circumstances, `conda` was falling back to breakable symlinks rather than using safer hardlinks when "copying" code from its package cache. When `conda` selects symlinks, a `clean --all` can damage irretrievably a conda env. Avoid this by only cleaning the index and tarballs, but not the unpacked files that are potentially the targets of said symlinks.