### PR TITLE
Update deprecated upload-artifact v2 action

### DIFF
--- a/.github/workflows/btd_test.yml
+++ b/.github/workflows/btd_test.yml
@@ -25,7 +25,7 @@ jobs:
           token: ${{ github.token }}
           skip-deploy: true
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs/_build/html


### PR DESCRIPTION
GitHub deprecated v2 of the artifact actions.

https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/