### PR TITLE
Hotfix: ssh_config(5) Match host clauses must be comma-separated.

### DIFF
--- a/docs/Userguide_login.rst
+++ b/docs/Userguide_login.rst
@@ -333,7 +333,7 @@ advanced use-cases, you may use the following as inspiration:
         Hostname  login-5.login.server.mila.quebec
     Host cn-????
         Hostname             %h.server.mila.quebec
-    Match host *.server.mila.quebec !*login.server.mila.quebec
+    Match host !*login.server.mila.quebec,*.server.mila.quebec
         Hostname                 %h
         ProxyJump                mila
     Match host           *login.server.mila.quebec


### PR DESCRIPTION
`Host` prend ` `, `Match host` prend `,`.