### PR TITLE
Fix Sphinx build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,6 @@
 from __future__ import division, print_function, unicode_literals
 
 import subprocess
-import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -19,7 +18,7 @@ extensions = [
 ]
 
 templates_path = ["templates", "_templates", ".templates"]
-source_suffix = [".rst", ".md"]
+source_suffix = [".rst"]
 master_doc = "index"
 project = "Mila Technical Documentation"
 copyright = str(datetime.now().year)
@@ -42,6 +41,8 @@ exclude_patterns = [
     "IDT_*",
     "singularity/*",
     "examples/**/README.rst",
+    "*.md",
+    "**/*.md",
     # 'examples/*',
 ]
 # The name of the Pygments (syntax highlighting) style to use.


### PR DESCRIPTION
"Fixes" the sphinx build by making it ignore all markdown files.

- There are lots of red warnings about a TOC like this:
```
/home/fabrice/repos/mila-docs/docs/index.rst:21: WARNING: toctree contains reference to document 'Userguide_comms' that doesn't have a title: no link will be generated
```

But, the docs look fine.

Signed-off-by: Fabrice Normandin <normandf@mila.quebec>