### PR TITLE
Fix mkdocs build on readthedocs

### DIFF
--- a/.mkdocs/.readthedocs.yaml
+++ b/.mkdocs/.readthedocs.yaml
@@ -21,7 +21,10 @@ build:
     create_environment:
       - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
     install:
-      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --dev
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync
+    pre_build:
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv run
+        --script docs/examples/preprocess.py
 
 mkdocs:
   configuration: mkdocs.yml


### PR DESCRIPTION
Fix the mkdocs build on readthedocs by executing the examples preprocess.py script in the pre-build phase. This makes the *.diff files available to be included in the index.md pages
