### PR TITLE
Add a banner to point to new docs site

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,13 @@ file_insertion_enabled = False
 latex_documents = [
     ("index", "mila-docs.tex", "Mila technical Documentation", "", "manual"),
 ]
+rst_prolog = """\
+.. warning::
+
+    You are currently viewing an old version of the documentation.
+
+    Please visit https://docs.mila.quebec for up-to-date information and an improved UI.
+"""
 
 exclude_patterns = [
     "_build",


### PR DESCRIPTION
Should be merged into Master (or whichever branch will hold the sphinx docs) after the mkdocs version becomes the one hosted at https://docs.mila.quebec

Signed-off-by: Fabrice Normandin <normandf@mila.quebec>