### PR TITLE
Add Utterances comments to docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 ---
 title: Mila Technical Documentation
 description: Technical documentation for Mila's computing infrastructure.
+comments: true
 ---
 
 # Mila technical documentation

--- a/overrides/partials/comments.html
+++ b/overrides/partials/comments.html
@@ -1,0 +1,18 @@
+{% if page.meta.comments %}
+<h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
+<!--
+  Giscus configuration: Get your repo-id and category-id from https://utteranc.es/
+  1. Install the Giscus GitHub App: https://github.com/apps/utterances
+  2. Enable Discussions on your repository
+  3. Visit https://utteranc.es/ and generate the snippet for mila-iqia/mila-docs
+  4. Replace the data-repo-id and data-category-id values below
+-->
+<script src="https://utteranc.es/client.js"
+  repo="mila-iqia/mila-docs"
+  issue-term="pathname"
+  label="comment"
+  theme="preferred-color-scheme"
+  crossorigin="anonymous"
+  async>
+</script>
+{% endif %}


### PR DESCRIPTION

## Summary
Enables GitHub-based comments on docs pages via Utterances and adds a `comments` front matter flag so pages can opt in.

## Changes
- Add `comments: true` to `docs/README.md` front matter to enable comments on the main docs page.
- Add `overrides/partials/comments.html` partial that loads the Utterances script when `page.meta.comments` is set.
- Comments section is shown only when `comments: true` is set in a page’s front matter.

## Notes
- Utterances setup: install the Utterances GitHub App, enable Discussions on the repo, and configure `repo-id` and `category-id` at [utteranc.es](https://utteranc.es/) for `mila-iqia/mila-docs`.