### PR TITLE
Add Hypothesis embed to docs

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,9 +1,19 @@
 {% extends "base.html" %}
 
 {% block announce %}
-🎉 We're giving the docs a fresh makeover! You can expect things to move around a bit while we redesign and reorganize the documentation.
-Fear not — the old docs are still available at <a href="https://mila-docs.readthedocs.io">mila-docs.readthedocs.io</a>.
-Spotted a
-bug? 🐛 <a href="https://github.com/mila-iqia/mila-docs/issues/new">File a
-    ticket</a> and we'll take a look at it!
+🎉 We're giving the docs a fresh makeover! You can expect things to move around
+a bit while we redesign and reorganize the documentation. Fear not — the old
+docs are still available at
+<a href="https://mila-docs.readthedocs.io">mila-docs.readthedocs.io</a>. Spotted
+a bug? 🐛
+<a href="https://github.com/mila-iqia/mila-docs/issues/new">File a ticket</a>
+and we'll take a look at it!
+{% endblock %}
+
+{% block extrahead %}
+{{ super() }}
+<script type="application/json" class="js-hypothesis-config">
+  {"showHighlights": false}
+</script>
+<script src="https://hypothes.is/embed.js" async></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
Adds the Hypothesis annotation embed to the docs site and reformats the announce block. Highlights are turned off via config.

## Changes
- Add `{% block extrahead %}` in `overrides/main.html` with Hypothesis embed script and `{"showHighlights": false}` config.
- Reformat announce block text (line breaks and spacing) for readability.

## Notes
- Hypothesis embed loads from `https://hypothes.is/embed.js`.
- https://web.hypothes.is/help/embedding-hypothesis-in-websites-and-platforms/