### PR TITLE
Add Google Analytics, feedback widget, and cookie consent to docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,10 +61,45 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
 
+extra:
+  analytics:
+    provider: google
+    property: G-2SSH8HHK4L
+    feedback:
+      title: Was this page helpful?
+      ratings:
+        - icon: material/emoticon-happy-outline
+          name: This page was helpful
+          data: 1
+          note: >-
+            Thanks for your feedback!
+        - icon: material/emoticon-sad-outline
+          name: This page could be improved
+          data: 0
+          note: >- 
+            Thanks for your feedback!
+  consent:
+    title: Cookie consent
+    description: >- 
+      We use cookies 🍪 to see which pages get the most love 💜, what folks
+      search for 🔍, and what gets downloaded 📥 — all anonymous, zero personal
+      data, no tracking of who your device or where you're from️. With your
+      consent, you're helping us make the docs better
+    actions:
+      - accept
+      - reject
+      - manage
+
+copyright: >
+  Copyright &copy; 2026 Mila –
+  <a href="#__consent">Change cookie settings</a>
+
 plugins:
   - include-markdown:
       dedent: true
   - literate-nav:
       nav_file: README.md
   - meta
+  # privacy plugin currently breaks giscus comments
+  # - privacy
   - search


### PR DESCRIPTION
## Summary
Adds Google Analytics and a page feedback widget, and a cookie consent banner to the docs.

## Changes
- **Analytics**: Google Analytics via `extra.analytics`
- **Feedback**: “Was this page helpful?” widget with two ratings (helpful / could be improved)
- **Cookie consent**: Banner with accept, reject, and manage options; copy explains anonymous usage (page views, search, downloads)
- **Footer**: Copyright 2026 and link to change cookie settings

## Notes
- https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/?h=feedback#was-this-page-helpful
- https://squidfunk.github.io/mkdocs-material/setup/ensuring-data-privacy/#cookie-consent-custom-initial-state