### PR TITLE
docs(examples): add GPU model alternatives and troubleshooting tip

### DIFF
--- a/docs/Userguide_quick_start_train_first_model.md
+++ b/docs/Userguide_quick_start_train_first_model.md
@@ -117,6 +117,12 @@ Submitted batch job 8888888
 
 You will see something like `Submitted batch job 8888888`. Note the job ID.
 
+!!! tip "Job stuck with `ReqNodeNotAvail`?"
+    The examples request an `l40s` GPU. If those nodes are temporarily
+    unavailable, you can override the GPU type at submit time:
+
+        sbatch --gpus-per-task=1 job.sh
+
 ## Monitor the job
 
 * **Queue status:** `squeue --me`

--- a/docs/examples/advanced/imagenet/job.sh
+++ b/docs/examples/advanced/imagenet/job.sh
@@ -2,6 +2,8 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=4
 #SBATCH --gpus-per-task=l40s:1
+## Or --gpus-per-task=rtx8000:1    to request a different GPU model
+## Or --gpus-per-task=1            for any GPU model
 #SBATCH --mem-per-gpu=16G
 #SBATCH --tmp=200G  # We need 200GB of storage on the local disk of each node.
 #SBATCH --time=02:00:00

--- a/docs/examples/distributed/multi_gpu/job.sh
+++ b/docs/examples/distributed/multi_gpu/job.sh
@@ -3,6 +3,8 @@
 #SBATCH --ntasks-per-node=2
 #SBATCH --cpus-per-task=4
 #SBATCH --gpus-per-task=l40s:1
+## Or --gpus-per-task=rtx8000:1    to request a different GPU model
+## Or --gpus-per-task=1            for any GPU model
 #SBATCH --mem-per-gpu=16G
 #SBATCH --time=00:15:00
 

--- a/docs/examples/distributed/multi_node/job.sh
+++ b/docs/examples/distributed/multi_node/job.sh
@@ -3,6 +3,7 @@
 #SBATCH --ntasks-per-node=2
 #SBATCH --cpus-per-task=4
 #SBATCH --gpus-per-task=l40s:1
+## Or --gpus-per-task=rtx8000:1    to request a different GPU model
 #SBATCH --mem-per-gpu=16G
 #SBATCH --time=00:15:00
 

--- a/docs/examples/distributed/single_gpu/job.sh
+++ b/docs/examples/distributed/single_gpu/job.sh
@@ -3,6 +3,8 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=4
 #SBATCH --gpus-per-task=l40s:1
+## Or --gpus-per-task=rtx8000:1    to request a different GPU model
+## Or --gpus-per-task=1            for any GPU model
 #SBATCH --mem-per-gpu=16G
 #SBATCH --time=00:15:00
 

--- a/docs/examples/frameworks/jax/job.sh
+++ b/docs/examples/frameworks/jax/job.sh
@@ -3,6 +3,8 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=4
 #SBATCH --gpus-per-task=l40s:1
+## Or --gpus-per-task=rtx8000:1    to request a different GPU model
+## Or --gpus-per-task=1            for any GPU model
 #SBATCH --mem-per-gpu=16G
 #SBATCH --time=00:15:00
 

--- a/docs/examples/frameworks/jax_setup/job.sh
+++ b/docs/examples/frameworks/jax_setup/job.sh
@@ -3,6 +3,8 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=1
 #SBATCH --gpus-per-task=l40s:1
+## Or --gpus-per-task=rtx8000:1    to request a different GPU model
+## Or --gpus-per-task=1            for any GPU model
 #SBATCH --mem-per-gpu=16G
 #SBATCH --time=00:15:00
 

--- a/docs/examples/frameworks/pytorch_setup/job.sh
+++ b/docs/examples/frameworks/pytorch_setup/job.sh
@@ -3,6 +3,8 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=1
 #SBATCH --gpus-per-task=l40s:1
+## Or --gpus-per-task=rtx8000:1    to request a different GPU model
+## Or --gpus-per-task=1            for any GPU model
 #SBATCH --mem-per-gpu=16G
 #SBATCH --time=00:15:00
 

--- a/docs/examples/good_practices/checkpointing/job.sh
+++ b/docs/examples/good_practices/checkpointing/job.sh
@@ -3,6 +3,8 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=4
 #SBATCH --gpus-per-task=l40s:1
+## Or --gpus-per-task=rtx8000:1    to request a different GPU model
+## Or --gpus-per-task=1            for any GPU model
 #SBATCH --mem-per-gpu=16G
 #SBATCH --time=00:15:00
 #SBATCH --requeue

--- a/docs/examples/good_practices/hpo_with_orion/job.sh
+++ b/docs/examples/good_practices/hpo_with_orion/job.sh
@@ -3,6 +3,8 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=4
 #SBATCH --gpus-per-task=l40s:1
+## Or --gpus-per-task=rtx8000:1    to request a different GPU model
+## Or --gpus-per-task=1            for any GPU model
 #SBATCH --mem-per-gpu=16G
 #SBATCH --time=00:15:00
 

--- a/docs/examples/good_practices/launch_many_jobs/job.sh
+++ b/docs/examples/good_practices/launch_many_jobs/job.sh
@@ -3,6 +3,8 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=4
 #SBATCH --gpus-per-task=l40s:1
+## Or --gpus-per-task=rtx8000:1    to request a different GPU model
+## Or --gpus-per-task=1            for any GPU model
 #SBATCH --mem-per-gpu=16G
 #SBATCH --time=00:15:00
 

--- a/docs/examples/good_practices/many_tasks_per_gpu/job.sh
+++ b/docs/examples/good_practices/many_tasks_per_gpu/job.sh
@@ -3,6 +3,8 @@
 #SBATCH --ntasks-per-gpu=2
 #SBATCH --cpus-per-task=4
 #SBATCH --gres=gpu:l40s:1
+## Or --gres=gpu:rtx8000:1    to request a different GPU model
+## Or --gres=gpu:1            for any GPU model
 #SBATCH --mem-per-gpu=16G
 #SBATCH --time=00:15:00
 

--- a/docs/examples/good_practices/slurm_job_arrays/job.sh
+++ b/docs/examples/good_practices/slurm_job_arrays/job.sh
@@ -3,6 +3,7 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=4
 #SBATCH --gpus-per-task=l40s:1
+## Or --gpus-per-task=rtx8000:1    to request a different GPU model
 #SBATCH --mem-per-gpu=16G
 #SBATCH --time=00:15:00
 

--- a/docs/examples/good_practices/wandb_setup/job.sh
+++ b/docs/examples/good_practices/wandb_setup/job.sh
@@ -3,6 +3,8 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=4
 #SBATCH --gpus-per-task=l40s:1
+## Or --gpus-per-task=rtx8000:1    to request a different GPU model
+## Or --gpus-per-task=1            for any GPU model
 #SBATCH --mem-per-gpu=16G
 #SBATCH --time=00:15:00
 


### PR DESCRIPTION
Add commented alternatives (`rtx8000`, any GPU) to example job scripts so users learn they can specify GPU models. Add a troubleshooting tip to the quickstart page for the `ReqNodeNotAvail` error.

Based on review feedback, keeps `l40s:1` as the default (appropriate size for example tasks). Multi-node and job array examples omit the "any GPU" option to avoid mixed-model issues.