### PR TITLE
Fix search results

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+<!-- START -->
 # Contributing to the Mila Docs
 
 Thank you for your interest into making a better documentation for all at Mila.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-{% include-markdown "../CONTRIBUTING.md" %}
+{% include-markdown "../CONTRIBUTING.md" start="<!-- START -->" %}

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,7 +83,7 @@ recommend you start by checking out the [short quick start guide](getting_starte
 </div>
 
 
-{% include-markdown "home/purpose.md" %}
+{% include-markdown "home/purpose.md" start="<!-- START -->" %}
 
 
 ## Contribution
@@ -91,7 +91,7 @@ If you find any errors in the documentation, missing or unclear sections, or wou
 
 ## Acknowledging Mila
 
-{% include-markdown "home/acknowledgement.md" %}
+{% include-markdown "home/acknowledgement.md" start="<!-- START -->" %}
 
 
 ## Documentation

--- a/docs/Userguide_login_mfa.md
+++ b/docs/Userguide_login_mfa.md
@@ -3,6 +3,7 @@ title: Multi-Factor Authentication (MFA)
 description: Configure MFA and use it to access the Mila cluster securely.
 ---
 
+<!-- START -->
 # Set Up Multi-Factor Authentication
 
 Multi-Factor Authentication (MFA) adds a security layer beyond SSH keys.

--- a/docs/examples/advanced/index.md
+++ b/docs/examples/advanced/index.md
@@ -1,7 +1,5 @@
 # Advanced Examples
 
-{%
-    include-markdown "examples/header.md"
-%}
+{% include-markdown "examples/header.md" start="<!-- START -->" %}
 
 - [Multi-Node / Multi-GPU ImageNet Training](imagenet/index.md)

--- a/docs/examples/distributed/index.md
+++ b/docs/examples/distributed/index.md
@@ -1,8 +1,6 @@
 # Distributed Training
 
-{%
-    include-markdown "examples/header.md"
-%}
+{% include-markdown "examples/header.md" start="<!-- START -->" %}
 
 - [Single GPU Job](single_gpu/index.md)
 - [Multi-GPU Job](multi_gpu/index.md)

--- a/docs/examples/frameworks/index.md
+++ b/docs/examples/frameworks/index.md
@@ -2,9 +2,7 @@
 # Software Frameworks
 
 
-{%
-    include-markdown "examples/header.md"
-%}
+{% include-markdown "examples/header.md" start="<!-- START -->" %}
 
 This section shows how to setup a development environment for various frameworks.
 These examples use [uv](../../technical_reference/general_theory/portability/#uv) to create a virtual environment and manage dependencies.

--- a/docs/examples/good_practices/index.md
+++ b/docs/examples/good_practices/index.md
@@ -1,8 +1,6 @@
 # Good practices
 
-{%
-    include-markdown "examples/header.md"
-%}
+{% include-markdown "examples/header.md" start="<!-- START -->" %}
 
 Work-in-progress: This section will contain minimal examples illustrating
 various good practices that should be observed when using the Mila cluster.

--- a/docs/examples/header.md
+++ b/docs/examples/header.md
@@ -1,3 +1,9 @@
+---
+search:
+  exclude: true
+---
+
+<!-- START -->
 ???+ note "About these examples"
 
     This section contains some minimal examples of how to run jobs on the Mila

--- a/docs/home/acknowledgement.md
+++ b/docs/home/acknowledgement.md
@@ -1,3 +1,4 @@
+<!-- START -->
 Researchers are requested to acknowledge Mila when publications or reports
 are published on research that used compute resources provided by the
 organization. Our ability to showcase the successful use of our resources

--- a/docs/home/cheatsheet.md
+++ b/docs/home/cheatsheet.md
@@ -1,3 +1,4 @@
+<!-- START -->
 # Cheat Sheet
 
 

--- a/docs/home/purpose.md
+++ b/docs/home/purpose.md
@@ -1,3 +1,9 @@
+---
+search:
+  exclude: true
+---
+
+<!-- START -->
 ## Purpose of this documentation
 
 This documentation aims to cover the information required to run scientific
@@ -7,8 +13,4 @@ members.
 It also aims to be an outlet for sharing know-how, tips and tricks and examples
 from the IDT team to the Mila researcher community.
 
-{%
-    include-markdown "home/purpose_audience.md"
-%}
-
-
+{% include-markdown "home/purpose_audience.md" start="<!-- START -->" %}

--- a/docs/home/purpose_audience.md
+++ b/docs/home/purpose_audience.md
@@ -1,3 +1,9 @@
+---
+search:
+  exclude: true
+---
+
+<!-- START -->
 ### Intended audience
 
 This documentation is mainly intended for Mila researchers having access to the Mila cluster. This access is determined by your researcher status.  <!--See [Roles and authorizations](../technical_reference/clusters/mila/roles_and_resources/#roles-and-authorizations) for more information. The core of the information with this purpose can be found in the following section: [Mila cluster](../technical_reference/clusters/mila/).-->

--- a/docs/hooks/sitemap_exclude.py
+++ b/docs/hooks/sitemap_exclude.py
@@ -1,0 +1,149 @@
+"""
+Hook: sitemap_exclude.py
+
+MkDocs Material's `search: exclude: true` frontmatter suppresses a page from the
+search index, but it does not remove the page from sitemap.xml. Without this
+hook, search-excluded pages would still appear in the sitemap and could be
+discovered and indexed by crawlers.
+
+This hook reuses the same `search: exclude: true` signal to also remove those
+pages from the sitemap, so no new frontmatter key is required.
+
+Build flow
+----------
+The hook runs across three MkDocs lifecycle phases within a single build:
+
+1. on_pre_build — clears the shared URL set so each build starts clean.
+2. on_page_context — inspects each rendered page; if it is marked ``search:
+   exclude: true``, its canonical URL is added to the set.
+3. on_post_build — edits sitemap.xml on disk to remove the collected URLs, then
+   regenerates sitemap.xml.gz.
+
+MkDocs Material produces two sitemap files: sitemap.xml (plain XML) and
+sitemap.xml.gz (the same content compressed with gzip). Both must be updated
+together — see on_post_build for details.
+
+Why post-build editing?
+MkDocs writes sitemap.xml during the build, before on_post_build fires. There is
+no earlier hook phase that can intercept sitemap generation, so patching the
+file on disk after the build completes is the only option.
+"""
+
+import gzip
+import logging
+import os
+import shutil
+import xml.etree.ElementTree as ET
+
+log = logging.getLogger("mkdocs.hooks.sitemap_exclude")
+
+# Module-level set so all three hook functions share state within one build.
+_excluded_urls: set[str] = set()
+
+
+def on_pre_build(config, **kwargs):
+    """Reset the excluded URL set at the start of every build.
+
+    ``mkdocs serve`` keeps the module loaded between incremental rebuilds, so
+    module-level state persists across builds. Resetting here ensures that URLs
+    collected during a previous build do not carry over into the next one.
+    """
+    global _excluded_urls
+    _excluded_urls = set()
+
+
+def on_page_context(context, page, config, nav, **kwargs):
+    """Collect canonical URLs for pages that opt out of search (and sitemap).
+
+    ``page.canonical_url`` is used because it is the exact URL MkDocs writes
+    into the sitemap's ``<loc>`` elements, making the lookup in on_post_build
+    reliable regardless of trailing-slash or base-URL configuration.
+    """
+    if page.meta.get("search", {}).get("exclude"):
+        if page.canonical_url:
+            _excluded_urls.add(page.canonical_url)
+            log.debug("sitemap_exclude: queued for removal: %s", page.canonical_url)
+    return context
+
+
+def on_post_build(config, **kwargs):
+    """Remove collected URLs from sitemap.xml and regenerate sitemap.xml.gz.
+
+    Inline comments below explain the two non-obvious implementation choices:
+    why the XML declaration is written manually, and why sitemap.xml.gz must be
+    regenerated after patching sitemap.xml.
+    """
+    if not _excluded_urls:
+        log.debug("sitemap_exclude: no pages to exclude, sitemap unchanged.")
+        return
+
+    site_dir = config["site_dir"]
+    sitemap_path = os.path.join(site_dir, "sitemap.xml")
+    sitemap_gz_path = sitemap_path + ".gz"
+
+    if not os.path.isfile(sitemap_path):
+        log.warning(
+            "sitemap_exclude: sitemap.xml not found at %s — skipping.", sitemap_path
+        )
+        return
+
+    # Register the sitemap namespace before parsing so ElementTree serialises it
+    # without an ugly "ns0:" prefix on output.
+    SITEMAP_NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
+    ET.register_namespace("", SITEMAP_NS)
+
+    try:
+        tree = ET.parse(sitemap_path)
+    except ET.ParseError as exc:
+        log.error("sitemap_exclude: failed to parse sitemap.xml: %s", exc)
+        return
+
+    root = tree.getroot()
+
+    # Detect Clark-notation namespace prefix from root tag (e.g.
+    # "{http://...}").
+    ns = root.tag.split("}")[0] + "}" if root.tag.startswith("{") else ""
+
+    removed = 0
+    for url_elem in root.findall(f"{ns}url"):
+        loc_elem = url_elem.find(f"{ns}loc")
+        if loc_elem is not None and loc_elem.text in _excluded_urls:
+            root.remove(url_elem)
+            removed += 1
+            log.info("sitemap_exclude: removed %s", loc_elem.text)
+
+    # Prepend the XML declaration manually instead of using
+    # ET.write(xml_declaration=True). That flag would automatically add the
+    # <?xml ...?> processing instruction, but Python's ElementTree always
+    # formats it with single-quoted attributes:
+    #   <?xml version='1.0' encoding='utf-8'?>
+    # MkDocs Material writes the declaration with double-quoted attributes and
+    # uppercase encoding:
+    #   <?xml version="1.0" encoding="UTF-8"?>
+    # Overwriting the file with the single-quoted form would introduce a
+    # persistent, cosmetic diff on every build. Writing the declaration as a
+    # byte literal keeps the output byte-for-byte identical to what Material
+    # originally produced.
+    xml_bytes = b'<?xml version="1.0" encoding="UTF-8"?>\n' + ET.tostring(
+        root, encoding="unicode"
+    ).encode("utf-8")
+
+    with open(sitemap_path, "wb") as fh:
+        fh.write(xml_bytes)
+
+    log.info("sitemap_exclude: wrote cleaned sitemap.xml (%d URL(s) removed).", removed)
+
+    # Regenerate sitemap.xml.gz to keep it in sync with the patched sitemap.xml.
+    # MkDocs Material produces two sitemap files: sitemap.xml is plain XML, and
+    # sitemap.xml.gz is the same content compressed with gzip. Many crawlers,
+    # including Googlebot, fetch the compressed version directly to save
+    # bandwidth. If only sitemap.xml were patched, the two files would diverge
+    # and different crawlers would see different content. The .gz file is only
+    # regenerated if Material produced it during this build.
+    if os.path.isfile(sitemap_gz_path):
+        with (
+            open(sitemap_path, "rb") as f_in,
+            gzip.open(sitemap_gz_path, "wb", compresslevel=9) as f_out,
+        ):
+            shutil.copyfileobj(f_in, f_out)
+        log.info("sitemap_exclude: regenerated sitemap.xml.gz.")

--- a/docs/technical_reference/cheatsheet.md
+++ b/docs/technical_reference/cheatsheet.md
@@ -1,3 +1,1 @@
-{%
-    include-markdown "home/cheatsheet.md"
-%}
+{% include-markdown "home/cheatsheet.md" start="<!-- START -->" %}

--- a/docs/technical_reference/clusters/drac/index.md
+++ b/docs/technical_reference/clusters/drac/index.md
@@ -1,3 +1,4 @@
+<!-- START -->
 # Digital Research Alliance of Canada Clusters
 
 

--- a/docs/technical_reference/clusters/external/extra_compute_industry.md
+++ b/docs/technical_reference/clusters/external/extra_compute_industry.md
@@ -1,0 +1,6 @@
+---
+search:
+  exclude: true
+---
+
+<!-- START -->

--- a/docs/technical_reference/clusters/external/extra_compute_large.md
+++ b/docs/technical_reference/clusters/external/extra_compute_large.md
@@ -1,0 +1,6 @@
+---
+search:
+  exclude: true
+---
+
+<!-- START -->

--- a/docs/technical_reference/clusters/external/extra_compute_university.md
+++ b/docs/technical_reference/clusters/external/extra_compute_university.md
@@ -1,0 +1,6 @@
+---
+search:
+  exclude: true
+---
+
+<!-- START -->

--- a/docs/technical_reference/clusters/external/index.md
+++ b/docs/technical_reference/clusters/external/index.md
@@ -6,19 +6,23 @@ resources outside the Mila cluster itself.
 {%
     include-markdown "technical_reference/clusters/drac/index.md"
     heading-offset=1
+    start="<!-- START -->"
 %}
 <!-- TODO: Remove these, they are empty in both the .rst and .md docs: -->
 {%
     include-markdown "technical_reference/clusters/external/extra_compute_university.md"
     heading-offset=1
+    start="<!-- START -->"
 %}
 
 {%
     include-markdown "technical_reference/clusters/external/extra_compute_industry.md"
     heading-offset=1
+    start="<!-- START -->"
 %}
 
 {%
     include-markdown "technical_reference/clusters/external/extra_compute_large.md"
     heading-offset=1
+    start="<!-- START -->"
 %}

--- a/docs/technical_reference/clusters/mila/index.md
+++ b/docs/technical_reference/clusters/mila/index.md
@@ -3,7 +3,7 @@
 This section seeks to provide factual information and policies on the Mila cluster computing environments.
 
 !!! note "Acknowledging Mila"
-    {% include-markdown "home/acknowledgement.md" %}
+    {% include-markdown "home/acknowledgement.md" start="<!-- START -->" %}
 
 <!--nav-->
 * [Roles and authorizations](../../../technical_reference/clusters/mila/roles_and_resources)

--- a/docs/technical_reference/clusters/mila/monitoring.md
+++ b/docs/technical_reference/clusters/mila/monitoring.md
@@ -33,7 +33,7 @@ For example, if we have a job running on `cn-c001`, we can type
 `cn-c001.server.mila.quebec:19999` in a browser address bar and the following
 page will appear.
 
-![monitoring](../../../../_static/images/monitoring.png)
+![monitoring](../../../_static/images/monitoring.png)
 
 
 ## Example watching the CPU/RAM/GPU usage
@@ -53,7 +53,7 @@ make sure that this resources is always kept busy.
 * CPU
     * iowait (pink line): High values means your model is waiting on IO a lot (disk or network).
 
-![monitoring_cpu](../../../../_static/images/monitoring_cpu.png)
+![monitoring_cpu](../../../_static/images/monitoring_cpu.png)
 
 * CPU RAM
     * You can see how much CPU RAM is being used by your script in practice,
@@ -63,7 +63,7 @@ make sure that this resources is always kept busy.
       because they run out of RAM. However, you should not request blindly 32GB of RAM
       when you actually require only 8GB.
 
-![monitoring_ram](../../../../_static/images/monitoring_ram.png)
+![monitoring_ram](../../../_static/images/monitoring_ram.png)
 
 * GPU
     * Monitors the GPU usage using an [nvidia-smi plugin for Netdata](https://learn.netdata.cloud/docs/agent/collectors/python.d.plugin/nvidia_smi/).
@@ -82,7 +82,7 @@ make sure that this resources is always kept busy.
       to other researchers who have experiments that can make best use of them.
       Sometimes you really just need a k80 and not a v100.
 
-![monitoring_gpu](../../../../_static/images/monitoring_gpu.png)
+![monitoring_gpu](../../../_static/images/monitoring_gpu.png)
 
 * Other users or jobs
     * If the node seems unresponsive or slow,
@@ -92,10 +92,10 @@ make sure that this resources is always kept busy.
       but in practice it is useful to be able to
       inspect this to diagnose certain problems.
 
-![monitoring_users](../../../../_static/images/monitoring_users.png)
+![monitoring_users](../../../_static/images/monitoring_users.png)
 
 
 ## Example with Mila dashboard
 
 
-![mila dashboard](../../../../_static/images/mila_dashboard_2021-06-15.png)
+![mila dashboard](../../../_static/images/mila_dashboard_2021-06-15.png)

--- a/docs/technical_reference/general_theory/cluster_parts.md
+++ b/docs/technical_reference/general_theory/cluster_parts.md
@@ -13,7 +13,7 @@ designed for high-performance computations, but clusters can also use
 specialized nodes to offer parallel file systems, databases, login nodes and
 even the cluster scheduling functionality as pictured in the image below.
 
-![Cluster overview](../../../_static/images/cluster_overview2.png)
+![Cluster overview](../../_static/images/cluster_overview2.png)
 
 We will overview the different types of nodes which you can encounter on a
 typical cluster.

--- a/docs/technical_reference/general_theory/multinode.md
+++ b/docs/technical_reference/general_theory/multinode.md
@@ -2,7 +2,7 @@
 <!-- TODO: Add link to the distributed and multi-node examples in the minimal examples section. -->
 ## Data Parallel
 
-![Data Parallel diagram](../../../_static/images/dataparallel.png)
+![Data Parallel diagram](../../_static/images/dataparallel.png)
 
 Request 3 nodes with at least 4 GPUs each.
 

--- a/docs/technical_reference/general_theory/portability.md
+++ b/docs/technical_reference/general_theory/portability.md
@@ -28,7 +28,7 @@ To achieve this, try to always keep in mind the following aspects:
 
 
 {%
-  include-markdown "technical_reference/general_theory/python.md"
+  include-markdown "technical_reference/general_theory/python.md" start="<!-- START -->"
 %}
 
 
@@ -42,7 +42,7 @@ module load python/3.10
 ```
 
 {%
-  include-markdown "technical_reference/general_theory/portability_modules.md"
+  include-markdown "technical_reference/general_theory/portability_modules.md" start="<!-- START -->"
 %}
 
 

--- a/docs/technical_reference/general_theory/portability_modules.md
+++ b/docs/technical_reference/general_theory/portability_modules.md
@@ -1,3 +1,9 @@
+---
+search:
+  exclude: true
+---
+
+<!-- START -->
 ### The module command
 
 For a list of available modules, simply use:

--- a/docs/technical_reference/general_theory/python.md
+++ b/docs/technical_reference/general_theory/python.md
@@ -1,3 +1,9 @@
+---
+search:
+  exclude: true
+---
+
+<!-- START -->
 ## Virtual environments
 
 A virtual environment in Python is a local, isolated environment in which you

--- a/docs/toolbox/singularity.md
+++ b/docs/toolbox/singularity.md
@@ -2,10 +2,13 @@
 
 {%
     include-markdown "toolbox/singularity_overview.md"
+    start="<!-- START -->"
 %}
 {%
     include-markdown "toolbox/singularity_building.md"
+    start="<!-- START -->"
 %}
 {%
     include-markdown "toolbox/singularity_on_clusters.md"
+    start="<!-- START -->"
 %}

--- a/docs/toolbox/singularity_building.md
+++ b/docs/toolbox/singularity_building.md
@@ -1,3 +1,9 @@
+---
+search:
+  exclude: true
+---
+
+<!-- START -->
 ## Building the containers
 
 Building a container is like creating a new environment except that containers

--- a/docs/toolbox/singularity_on_clusters.md
+++ b/docs/toolbox/singularity_on_clusters.md
@@ -1,3 +1,9 @@
+---
+search:
+  exclude: true
+---
+
+<!-- START -->
 ## Using containers on clusters
 
 ### How to use containers on clusters

--- a/docs/toolbox/singularity_overview.md
+++ b/docs/toolbox/singularity_overview.md
@@ -1,3 +1,9 @@
+---
+search:
+  exclude: true
+---
+
+<!-- START -->
 ## Overview
 
 ### What is Singularity?

--- a/docs/userguides/cluster_access.md
+++ b/docs/userguides/cluster_access.md
@@ -1,3 +1,9 @@
+---
+search:
+  exclude: true
+---
+
+<!-- START -->
 To access the Mila Cluster clusters, you will need a Mila account. Please contact
 Mila systems administrators if you don't have it already. Our IT support service
 is available here: https://it-support.mila.quebec/

--- a/docs/userguides/login.md
+++ b/docs/userguides/login.md
@@ -2,6 +2,7 @@
 
 {%
     include-markdown "userguides/cluster_access.md"
+    start="<!-- START -->"
 %}
 
 

--- a/docs/userguides/login_mfa.md
+++ b/docs/userguides/login_mfa.md
@@ -1,1 +1,1 @@
-{% include-markdown "Userguide_login_mfa.md" %}
+{% include-markdown "Userguide_login_mfa.md" start="<!-- START -->" %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,6 +126,7 @@ extra_css:
 
 hooks:
   - docs/hooks/skill_tags.py
+  - docs/hooks/sitemap_exclude.py
 
 plugins:
   - meta


### PR DESCRIPTION
## Summary
Adds `<!-- START -->` markers and `start=` filters to `include-markdown` directives to prevent front matter and heading duplication when files are transcluded.

## Changes
- Added `<!-- START -->` markers to all included markdown files (acknowledgement, cheatsheet, purpose, singularity, userguides, examples header, etc.) and updated all `include-markdown` calls with `start="<!-- START -->"` to skip front matter.
- Added `search: exclude: true` front matter to files that are only meant to be included (not indexed directly), such as `purpose.md`, `purpose_audience.md`, `python.md`, `portability_modules.md`, singularity partials, and external cluster stubs.

## Notes
- The `search: exclude: true` additions prevent partial/included files from appearing as standalone search results in MkDocs.

resolves #381 