### PR TITLE
Polish Getting Started guides and fix image paths

### DIFF
--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -4,9 +4,9 @@ description: >-
   Obtain a Mila account, set up MFA, install uv and milatools,
   and connect to the cluster for the first time.
 skills:
-  - skill-mila-account-setup
-  - skill-mila-connect-cluster
-  - skill-mila-local-setup
+  - __skill-mila-account-setup
+  - __skill-mila-connect-cluster
+  - __skill-mila-local-setup
 ---
 
 # Get Started with the Cluster
@@ -20,7 +20,7 @@ setting up the tools needed to run jobs. Follow the steps in order.
 
     1. Ask your supervisor how to get invited into the Mila organization and
        obtain your `@mila.quebec` account.
-    2. After the supervisor submits the application, a confirmation email will
+    2. After your supervisor submits the application, a confirmation email will
        arrive from IT support with instructions to access the account and
        connect to the cluster.
     
@@ -101,7 +101,7 @@ setting up the tools needed to run jobs. Follow the steps in order.
 ## Set up Multi-Factor Authentication (MFA) { #set-up-mfa }
 
 Cluster access requires **two factors**: an SSH key (first factor) and a second
-factor (TOTP, push notification, or email token). The MFA setup must be
+factor (TOTP, push notification, or email token). The MFA setup **must** be
 completed before connecting via SSH.
 
 ### Get your registration token
@@ -111,6 +111,12 @@ Your temporary access registrationcode*; it contains a **one-time registration
 token** that expires after use.
 
 ### First-time MFA setup
+
+!!! warning "Set up TOTP before leaving"
+    After the first visit, the MFA web portal will **only** accepts a TOTP code.
+    Leaving without setting up TOTP locks out the account, and a new
+    registration token will be needed from [IT
+    support](https://it-support.mila.quebec).
 
 1. Go to **https://mfa.mila.quebec**.
 
@@ -147,19 +153,13 @@ token** that expires after use.
 
         ![Token-selector](../_static/screenshots/mfa-enroll-token-totp-2.png)
 
-!!! warning "Set up TOTP before leaving"
-    After the first visit, the MFA web portal **only** accepts a TOTP code.
-    Leaving without setting up TOTP locks out the account, and a new
-    registration token will be needed from [IT
-    support](https://it-support.mila.quebec).
-
-## Install `uv` on your local machine
+## Install `uv` on a local machine
 
 `uv` is a fast Python package manager and workflow tool, that serves as a
 drop-in replacement for `pip` and `virtualenv`, for quickly installing project
 dependencies, managing packages, and creating isolated Python environments.
 
-On your **local machine**, run:
+On a **personal computer**, run:
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -189,7 +189,11 @@ everything's installed!
 
 ### Install `milatools`
 
-Install `milatools` locally (after [installing `uv`](#install-uv-on-your-local-machine)):
+`milatools` is a command-line tool that simplifies connecting to the Mila
+cluster. It configures SSH automatically and provides `mila code` to open VSCode
+directly on a compute node.
+
+Install a **personal computer** (after [installing `uv`](#install-uv-on-a-local-machine)):
 
 ```bash
 uv tool install --upgrade milatools
@@ -212,7 +216,8 @@ See the [milatools README](https://github.com/mila-iqia/milatools) for more deta
 
 ### Configure `milatools`
 
-Run `mila init` with your cluster username ready. This sets up the SSH config, public keys, and passwordless auth.
+Run `mila init` with your cluster username ready. This sets up the SSH config,
+public keys, and passwordless auth.
 
 ```bash
 mila init           
@@ -304,6 +309,10 @@ Last login: Fri Feb 27 09:29:48 2026 from 74.58.126.98
 ```
 </div>
 
+After entering the OTP, the session opens on a **login node** — a shared entry
+point to the cluster. Login nodes are for submitting jobs and managing files,
+not for running computations directly.
+
 ??? question "Not prompted to enter an OTP?"
 
     Review the steps to [install and configure `milatools`](#install-milatools).
@@ -337,7 +346,7 @@ everything's installed!
 
 `uv`
 :   Fast Python package manager and virtual environment tool. Used on both
-    the local machine and the cluster.
+    a local machine and the cluster.
 
 `milatools`
 :   CLI tool (`mila`) for setting up SSH config and opening VSCode on

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -96,6 +96,8 @@ setting up the tools needed to run jobs. Follow the steps in order.
 * Verify the SSH connection to the cluster.
 * Install `uv` on the cluster.
 
+---
+
 ## Set up Multi-Factor Authentication (MFA) { #set-up-mfa }
 
 Cluster access requires **two factors**: an SSH key (first factor) and a second
@@ -112,7 +114,7 @@ token** that expires after use.
 
 1. Go to **https://mfa.mila.quebec**.
 
-    ![Login-interface](screenshots/mfa-login.png)
+    ![Login-interface](../_static/screenshots/mfa-login.png)
 
 2. **Username:** your cluster username (**not** your `@mila.quebec` email
    address).
@@ -123,7 +125,7 @@ token** that expires after use.
 4. After logging in, **immediately** add at least one **TOTP** token to your
    account:
 
-    ![Token-selector](screenshots/mfa-enroll-token-totp.png)
+    ![Token-selector](../_static/screenshots/mfa-enroll-token-totp.png)
 
     1. Install a TOTP authenticator app:
 
@@ -143,7 +145,7 @@ token** that expires after use.
     2. In the authenticator app, scan the QR code shown on the MFA page to add
        the token:
 
-        ![Token-selector](screenshots/mfa-enroll-token-totp-2.png)
+        ![Token-selector](../_static/screenshots/mfa-enroll-token-totp-2.png)
 
 !!! warning "Set up TOTP before leaving"
     After the first visit, the MFA web portal **only** accepts a TOTP code.
@@ -302,11 +304,11 @@ Last login: Fri Feb 27 09:29:48 2026 from 74.58.126.98
 ```
 </div>
 
-!!! failure "Not prompted to enter an OTP?"
+??? question "Not prompted to enter an OTP?"
 
     Review the steps to [install and configure `milatools`](#install-milatools).
 
-!!! failure "The Login node banner does not appear after entering the OTP?"
+??? question "The Login node banner does not appear after entering the OTP?"
 
     Review the steps to [set up Multi-Factor Authentication](#set-up-mfa).
 
@@ -349,8 +351,8 @@ everything's installed!
 
 ## Next steps
 
-Once the access to the cluster is established, head to the following sections to
-run a first job and train a first model:
+With cluster access established, proceed to the following guides to run a first
+job and train a first model:
 
 <div class="grid cards" markdown>
 
@@ -358,7 +360,6 @@ run a first job and train a first model:
     { .card }
 
     ---
-
     Run your first job on the cluster with PyTorch using VSCode on a GPU compute
     node.
 
@@ -366,7 +367,6 @@ run a first job and train a first model:
     { .card }
 
     ---
-
     Train a ResNet18 on CIFAR-10 on a single GPU using `sbatch`.
 
 </div>

--- a/docs/getting_started/my_first_job.md
+++ b/docs/getting_started/my_first_job.md
@@ -4,7 +4,7 @@ description: >-
   Create a minimal PyTorch project, open VSCode on a GPU compute node
   using mila code, and verify CUDA availability.
 skills:
-  - skill-mila-run-jobs
+  - __skill-mila-run-jobs
 ---
 
 # Run Your First Job
@@ -34,13 +34,12 @@ code`](https://github.com/mila-iqia/milatools) command from
 
     The `mila code` command opens [VSCode](https://code.visualstudio.com/) (or a
     compatible editor such as Cursor) on a compute node. [Install
-    VSCode](https://code.visualstudio.com/Download) on your local machine before
-    starting.
+    VSCode](https://code.visualstudio.com/Download) on a personal computer
+    before starting.
 
 ## What this guide covers
 
-* Open VSCode on a compute node with one GPU using `mila code` (from your local
-  machine).
+* Open VSCode on a compute node with one GPU using `mila code`.
 * Create a minimal PyTorch project with `pyproject.toml` and `main.py`.
 * Run the script with `uv run python main.py` in VSCode.
 
@@ -50,8 +49,8 @@ code`](https://github.com/mila-iqia/milatools) command from
 
 ### Create the project directory on the cluster
 
-From your **local machine**, create the project directory on the cluster so that
-`mila code` can open it (the path is on the cluster):
+From a **personal computer**, create the project directory on the cluster so
+that `mila code` can open it (the path is on the cluster):
 
 ```bash
 ssh mila 'mkdir -p CODE/my_first_job'
@@ -102,16 +101,16 @@ the compute node.
 In VSCode, create the following two files in the project folder (e.g. in the
 explorer or via **File → New File**). The files live on the compute node.
 
-=== "pyproject.toml"
-
-    ```toml title="pyproject.toml"
-    --8<-- "docs/examples/frameworks/pytorch_setup/pyproject.toml"
-    ```
-
 === "main.py"
 
     ```py title="main.py"
     --8<-- "docs/examples/frameworks/pytorch_setup/main.py"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml title="pyproject.toml"
+    --8<-- "docs/examples/frameworks/pytorch_setup/pyproject.toml"
     ```
 
 ### Run the script in the VSCode terminal

--- a/docs/getting_started/my_first_job.md
+++ b/docs/getting_started/my_first_job.md
@@ -15,7 +15,7 @@ cluster using [VSCode](VSCode.md) on a compute node via the [`mila
 code`](https://github.com/mila-iqia/milatools) command from
 [milatools](https://github.com/mila-iqia/milatools).
 
-## Prerequisites
+## Before you begin
 
 <div class="grid cards" markdown>
 
@@ -23,7 +23,6 @@ code`](https://github.com/mila-iqia/milatools) command from
     { .card }
 
     ---
-
     Get your Mila account, enable cluster access and MFA, then install `uv` and
     `milatools` to connect via SSH.
 
@@ -139,6 +138,8 @@ The output should confirm that PyTorch is built with CUDA and detects the GPU.
 When done, close VSCode and press **Ctrl+C** in the terminal to end the `mila
 code` session and relinquish the allocation.
 
+---
+
 ## Key concepts
 
 `mila code`
@@ -155,7 +156,6 @@ code` session and relinquish the allocation.
     { .card }
 
     ---
-
     Train a ResNet18 on CIFAR-10 on a single GPU using `sbatch`.
 
 &nbsp;

--- a/docs/getting_started/train_first_model.md
+++ b/docs/getting_started/train_first_model.md
@@ -4,7 +4,7 @@ description: >-
   Train a ResNet18 on CIFAR-10 on a single GPU using sbatch, including
   data staging to $SLURM_TMPDIR.
 skills:
-  - skill-mila-run-jobs
+  - __skill-mila-run-jobs
 ---
 
 # Train Your First Model
@@ -46,8 +46,8 @@ fast local storage, and runs a Slurm batch job.
 
 ### Create the project directory on the cluster
 
-From your **local machine**, create the project directory on the cluster so that
-`mila code` can open it (the path is on the cluster):
+From a **personal computer**, create the project directory on the cluster so
+that `mila code` can open it (the path is on the cluster):
 
 ```bash
 ssh mila 'mkdir -p CODE/train_first_model'
@@ -90,12 +90,6 @@ salloc: Granted job allocation 8888888
     --8<-- "docs/examples/distributed/single_gpu/job.sh"
     ```
 
-=== "pyproject.toml"
-
-    ```toml title="pyproject.toml"
-    --8<-- "docs/examples/distributed/single_gpu/pyproject.toml"
-    ```
-
 === "main.py"
 
     The training script uses PyTorch to load CIFAR-10 from `$SLURM_TMPDIR/data`,
@@ -104,6 +98,12 @@ salloc: Granted job allocation 8888888
 
     ```py title="main.py"
     --8<-- "docs/examples/distributed/single_gpu/main.py"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml title="pyproject.toml"
+    --8<-- "docs/examples/distributed/single_gpu/pyproject.toml"
     ```
 
 ## Submit the job

--- a/docs/getting_started/train_first_model.md
+++ b/docs/getting_started/train_first_model.md
@@ -13,7 +13,7 @@ This guide covers training a small model (ResNet18) on CIFAR-10 using a single
 GPU on the Mila cluster. The guide uses Mila's CIFAR-10 dataset, stages it into
 fast local storage, and runs a Slurm batch job.
 
-## Prerequisites
+## Before you begin
 
 <div class="grid cards" markdown>
 
@@ -21,7 +21,6 @@ fast local storage, and runs a Slurm batch job.
     { .card }
 
     ---
-
     Get your Mila account, enable cluster access and MFA, then install `uv` and
     `milatools` to connect via SSH.
 
@@ -29,7 +28,6 @@ fast local storage, and runs a Slurm batch job.
     { .card }
 
     ---
-
     Run your first job on the cluster with PyTorch using VSCode on a GPU compute
     node.
 
@@ -44,7 +42,7 @@ fast local storage, and runs a Slurm batch job.
 
 ---
 
-## Open VSCode on a compute node
+## Open VSCode on a CPU node
 
 ### Create the project directory on the cluster
 
@@ -58,7 +56,7 @@ ssh mila 'mkdir -p CODE/train_first_model'
 ### Start VSCode on a CPU node
 
 Only code and job scripts will be prepared at this stage—not actually running
-training—so a CPU node suffices for a faster to allocate and a less
+training—so a CPU node suffices for a faster-to-allocate and less
 resource-intensive editor session.
 
 ```bash
@@ -124,16 +122,8 @@ Submitted batch job 8888888
 ```
 </div>
 
-The output will confirm the job was submitted (something like `Submitted batch
-job 8888888.` should be displayed). Note the job ID.
-
-
-!!! tip "Job stuck with `ReqNodeNotAvail`?"
-    The examples request an `l40s` GPU. If those nodes are temporarily
-    unavailable, you can override the GPU type at submit time:
-
-        sbatch --gpus-per-task=1 job.sh
-
+The output will confirm the submission of the job (e.g. `Submitted batch job
+8888888.`). Note the job ID.
 
 ## Monitor the job
 
@@ -147,21 +137,22 @@ job 8888888.` should be displayed). Note the job ID.
    8888888 username         long         job.sh   R 2026-03-16T19:48       1:08     1    4        N/A     16G cn-l016 (None) (null)
   ```
   </div>
-
-??? question "Job stuck with `ReqNodeNotAvail`"
-
-    No node matching the job's requirements is currently available — for
-    example, all nodes with the requested GPU type may be busy, or some nodes
-    may be DOWN or reserved for maintenance. This is **not** an error — the job
-    will start automatically once a matching node is free.
-
-    **Options:**
-
-    - **Wait.** The job will start on its own. Check back with `squeue --me`.
-    - **Request a different GPU type.** Cancel the queued job with `scancel
-      <JOBID>`, then resubmit with a different `--gres` flag, e.g.: `sbatch
-      --gres=gpu:rtx8000:1 job.sh`
   
+    ??? question "Job stuck with `ReqNodeNotAvail`"
+    
+        No node matching the job's requirements is currently available — for
+        example, all nodes with the requested GPU type may be busy, or some
+        nodes may be DOWN or reserved for maintenance. This is **not** an error
+        — the job will start automatically once a matching node is free.
+    
+        **Options:**
+    
+        - **Wait.** The job will start on its own. Check back with `squeue
+          --me`.
+        - **Request a different GPU type.** Cancel the queued job with `scancel
+          <JOBID>`, then resubmit with a different `--gres` flag, e.g.: `sbatch
+          --gres=gpu:rtx8000:1 job.sh`
+
 * **Watch the output file:** Once the job starts, a file `slurm-<JOBID>.out`
   will be created containing the job log. Open it to watch the model being
   trained:

--- a/docs/hooks/external_links.py
+++ b/docs/hooks/external_links.py
@@ -1,0 +1,16 @@
+import re
+
+_EXTERNAL_A_RE = re.compile(
+    r'<a(?=\s)([^>]*)href=["\']https?://[^"\']*["\']([^>]*)>',
+    re.IGNORECASE,
+)
+
+
+def on_page_content(html, page, config, **kwargs):
+    def add_new_tab(m):
+        tag = m.group(0)
+        if "target=" not in tag:
+            tag = tag[:-1] + ' target="_blank" rel="noopener noreferrer">'
+        return tag
+
+    return _EXTERNAL_A_RE.sub(add_new_tab, html)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,7 @@ extra_css:
   - stylesheets/extra.css
 
 hooks:
+  - docs/hooks/external_links.py
   - docs/hooks/skill_tags.py
 
 plugins:


### PR DESCRIPTION
## Summary
Improves clarity and flow of the three Getting Started guides with wording fixes, better section headings, and corrected screenshot paths. Also adds an MkDocs hook to open external links in a new tab.

## Changes
- Reworded and restructured `index.md`: clearer MFA warning placement, improved `milatools` description, changed failure admonitions to collapsible questions, and added horizontal rules for visual separation.
- Fixed broken screenshot paths (`screenshots/` → `../_static/screenshots/`) in `index.md`.
- Renamed "Prerequisites" to "Before you begin" in `my_first_job.md` and `train_first_model.md`.
- Clarified section title "Open VSCode on a CPU node" (was "compute node") in `train_first_model.md`.
- Moved `ReqNodeNotAvail` tip inside the monitor section as a nested collapsible in `train_first_model.md`; removed duplicate tip.
- Added `docs/hooks/external_links.py` hook to inject `target="_blank"` on all external links.
- Registered the new hook in `mkdocs.yml`.

## Notes
The `external_links.py` hook uses a regex over rendered HTML; it skips links that already have a `target=` attribute to avoid double-injection.

resolves #380