### PR TITLE
Add uv user guide for managing Python dependencies

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -106,6 +106,7 @@ If you find any errors in the documentation, missing or unclear sections, or wou
     - [Run Your First Job](getting_started/my_first_job.md)
     - [Train Your First Model](getting_started/train_first_model.md)
 - [How-tos and Guides](userguides/index.md)
+    - [Manage Python Dependencies with uv](userguides/python_uv.md)
     - [Multi-Factor Authentication (MFA) for Cluster Access](Userguide_login_mfa.md)
     - [Logging in to the cluster](userguides/login.md)
     - [Running your code](userguides/running_code.md)
@@ -167,4 +168,3 @@ If you find any errors in the documentation, missing or unclear sections, or wou
     - [🔗 Research Project Template](https://mila-iqia.github.io/ResearchTemplate)
 - [Get help](help/index.md)
     - [Frequently asked questions (FAQ)](help/faq.md)
-

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -1,8 +1,12 @@
 ---
 title: Get Started with the Cluster
 description: >-
-  Obtain a Mila account, set up MFA, install uv and milatools,
-  and connect to the cluster for the first time.
+  Obtain a Mila account, enable cluster access and MFA, install `uv` and
+  `milatools`, configure SSH access and connect to the cluster for the first
+  time.
+  #__skill-mila-account-setup
+  #__skill-mila-connect-cluster
+  #__skill-mila-local-setup
 skills:
   - __skill-mila-account-setup
   - __skill-mila-connect-cluster
@@ -369,13 +373,13 @@ job and train a first model:
     { .card }
 
     ---
-    Run your first job on the cluster with PyTorch using VSCode on a GPU compute
-    node.
+    Run your first job on the cluster with PyTorch using `mila code` and VSCode
+    on a GPU compute node.
 
 -   [:material-run-fast:{ .lg .middle } __Train Your First Model__](train_first_model.md)
     { .card }
 
     ---
-    Train a ResNet18 on CIFAR-10 on a single GPU using `sbatch`.
+    Train your first ResNet18 model on CIFAR-10 on a single GPU using `sbatch`.
 
 </div>

--- a/docs/getting_started/my_first_job.md
+++ b/docs/getting_started/my_first_job.md
@@ -1,8 +1,9 @@
 ---
 title: Run Your First Job
 description: >-
-  Create a minimal PyTorch project, open VSCode on a GPU compute node
-  using mila code, and verify CUDA availability.
+  Run your first job on the cluster with PyTorch using `mila code` and VSCode on
+  a GPU compute node.
+  #__skill-mila-run-jobs
 skills:
   - __skill-mila-run-jobs
 ---
@@ -23,8 +24,9 @@ code`](https://github.com/mila-iqia/milatools) command from
     { .card }
 
     ---
-    Get your Mila account, enable cluster access and MFA, then install `uv` and
-    `milatools` to connect via SSH.
+    Obtain a Mila account, enable cluster access and MFA, install `uv` and
+    `milatools`, configure SSH access and connect to the cluster for the first
+    time.
 
 &nbsp;
 
@@ -155,7 +157,7 @@ code` session and relinquish the allocation.
     { .card }
 
     ---
-    Train a ResNet18 on CIFAR-10 on a single GPU using `sbatch`.
+    Train your first ResNet18 model on CIFAR-10 on a single GPU using `sbatch`.
 
 &nbsp;
 

--- a/docs/getting_started/train_first_model.md
+++ b/docs/getting_started/train_first_model.md
@@ -1,8 +1,8 @@
 ---
 title: Train Your First Model
 description: >-
-  Train a ResNet18 on CIFAR-10 on a single GPU using sbatch, including
-  data staging to $SLURM_TMPDIR.
+  Train your first ResNet18 model on CIFAR-10 on a single GPU using `sbatch`.
+  #__skill-mila-run-jobs
 skills:
   - __skill-mila-run-jobs
 ---
@@ -21,15 +21,16 @@ fast local storage, and runs a Slurm batch job.
     { .card }
 
     ---
-    Get your Mila account, enable cluster access and MFA, then install `uv` and
-    `milatools` to connect via SSH.
+    Obtain a Mila account, enable cluster access and MFA, install `uv` and
+    `milatools`, configure SSH access and connect to the cluster for the first
+    time.
 
 -   [:material-run-fast:{ .lg .middle } __Run Your First Job__](my_first_job.md)
     { .card }
 
     ---
-    Run your first job on the cluster with PyTorch using VSCode on a GPU compute
-    node.
+    Run your first job on the cluster with PyTorch using `mila code` and VSCode
+    on a GPU compute node.
 
 </div>
 
@@ -187,3 +188,18 @@ The output will confirm the submission of the job (e.g. `Submitted batch job
 `srun`
 :   Runs a command inside the allocated resources. In the job script,
     `srun uv run python main.py` runs training on the GPU node.
+
+## Next step
+
+<div class="grid cards" markdown>
+
+-   [:material-run-fast:{ .lg .middle } __Manage Python Dependencies with `uv`__](../userguides/python_uv.md)
+    { .card }
+
+    ---
+    Install uv, manage project dependencies, run reproducible Slurm jobs, and run
+    standalone scripts.
+
+&nbsp;
+
+</div>

--- a/docs/userguides/index.md
+++ b/docs/userguides/index.md
@@ -4,6 +4,7 @@ Check out our guides picturing different ways to use the cluster:
 
 | Guide | Quick description |
 | ----- | ----------------- |
+| [Manage Python Dependencies with uv](../userguides/python_uv.md) | Set up uv to manage project dependencies |
 | [Multi-Factor authentication](../Userguide_login_mfa) | Use MFA to access the Mila cluster |
 | [Logging in to the cluster](../userguides/login) | Log in to the Mila cluster |
 | [Running your code](../userguides/running_code.md) | Run your code on the cluster |

--- a/docs/userguides/python_uv.md
+++ b/docs/userguides/python_uv.md
@@ -28,14 +28,13 @@ reproducibly, and submitting Slurm batch jobs.
 
 ## What this guide covers
 
-* Install `uv` on a local machine, on the Mila cluster, and on DRAC clusters
+* Install `uv` on a local machine and on the Mila cluster
 * Create a project and declare dependencies in `pyproject.toml`
 * Add, update, and remove packages
 * Understand how `uv` resolves dependencies safely
 * Reproduce the environment on a new node using `uv.lock`
 * Run standalone scripts with inline dependencies
 * Submit a Slurm job that runs your script with `uv run python`
-* Use `uv` on DRAC clusters
 
 ---
 
@@ -93,39 +92,6 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 !!! note "If `uv` is not found"
     If `uv --version` returns `command not found`, exit the SSH session and
     reconnect to apply the updated `PATH`.
-
-### On a DRAC cluster
-
-Connect to a DRAC login node, then run the same install command:
-
-```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-!!! warning "`uv` is not officially supported on DRAC"
-    DRAC does not provide support for `uv`. If you encounter issues using `uv`
-    on a DRAC cluster, contact the Mila IDT team on [Slack or during Office
-    Hours](../help/index.md).
-
-#### Configure `uv` on DRAC
-
-DRAC provides Python through environment modules rather than letting tools
-download their own interpreter. Tell `uv` to prefer the system Python by adding
-the following to `~/.config/uv/uv.toml` on your DRAC account:
-
-```toml title="~/.config/uv/uv.toml"
-python-preference = "system"
-```
-
-This file is read by `uv` whenever it runs on that cluster. Because it lives on
-DRAC's filesystem, it has no effect on your local machine or on the Mila
-cluster.
-
-!!! warning "Load a Python module before running `uv`"
-    With `python-preference = "system"`, `uv` looks for Python in your `PATH`.
-    If no Python module is loaded, `uv` may fail to find the right interpreter.
-    Always run `module load python/3.x` (or the version your project requires)
-    before calling `uv run` or `uv sync` on a DRAC node.
 
 ## Create a project
 
@@ -379,19 +345,6 @@ Submitted batch job 8888888
 the job always uses the pinned dependencies regardless of which compute node
 runs it.
 
-!!! warning "DRAC clusters"
-    `uv run` works the same way on DRAC with two requirements:
-
-    - Set `python-preference = "system"` in `~/.config/uv/uv.toml`
-      (see [Configure `uv` on DRAC](#configure-uv-on-drac)).
-    - Load a Python module in `job.sh` before calling `uv run`:
-
-    ```bash title="job.sh" linenums="10"
-    module load python/3.12
-
-    srun uv run python train.py
-    ```
-
 ---
 
 ## Key concepts
@@ -420,12 +373,6 @@ runs it.
 :   A named set of dependencies in `pyproject.toml`. The default development group
     (`--dev`) holds tools like `pytest` that are only needed during local
     development, not when running your research code on the cluster.
-
-`python-preference = "system"` (`~/.config/uv/uv.toml`)
-:   Tells `uv` to prefer a Python interpreter already present on the system (e.g.,
-    loaded via `module load`) rather than downloading its own. Set this once in
-    your DRAC user-level config so every project on that cluster uses the system
-    Python automatically.
 
 **PEP 723 script metadata**
 :   A `# /// script` block at the top of a `.py` file that declares the script's

--- a/docs/userguides/python_uv.md
+++ b/docs/userguides/python_uv.md
@@ -1,7 +1,8 @@
 ---
 title: Manage Python Dependencies with uv
 description: >-
-  Set up uv, declare dependencies, and run reproducible Slurm jobs.
+  Install uv, manage project dependencies, run reproducible Slurm jobs, install
+  CLI tools, and run standalone scripts.
 ---
 
 # Manage Python Dependencies with `uv`
@@ -19,8 +20,9 @@ reproducibly, and submitting Slurm batch jobs.
     { .card }
 
     ---
-    Obtain a Mila account, set up MFA, install `uv` and `milatools`, and connect to
-    the cluster for the first time.
+    Obtain a Mila account, enable cluster access and MFA, install `uv` and
+    `milatools`, configure SSH access and connect to the cluster for the first
+    time.
 
 &nbsp;
 
@@ -35,6 +37,7 @@ reproducibly, and submitting Slurm batch jobs.
 * Reproduce the environment on a new node using `uv.lock`
 * Run standalone scripts with inline dependencies
 * Submit a Slurm job that runs your script with `uv run python`
+* Install CLI tools system-wide with `uv tool`
 
 ---
 
@@ -259,48 +262,6 @@ Run a Python script with the project environment loaded:
 uv run python train.py
 ```
 
-### Standalone scripts with inline dependencies
-
-For one-off scripts or utilities that do not belong to a project, [PEP
-723](https://peps.python.org/pep-0723/) metadata lets you declare dependencies
-directly inside the script file.
-
-Use `uv add --script` to add dependencies to the script. `uv` will write the `#
-/// script` metadata block automatically:
-
-```bash
-uv add --script experiment.py numpy matplotlib
-```
-
-The resulting script looks like:
-
-```python title="experiment.py"
-# /// script
-# requires-python = ">=3.12"
-# dependencies = [
-#   "matplotlib",
-#   "numpy",
-# ]
-# ///
-
-import numpy as np
-import matplotlib.pyplot as plt
-
-data = np.random.randn(1000)
-plt.hist(data)
-plt.savefig("hist.png")
-```
-
-Run the script with:
-
-```bash
-uv run --script experiment.py
-```
-
-`uv` reads the metadata block, creates a temporary isolated environment with
-those exact dependencies, runs the script, and discards the environment. The
-project's `pyproject.toml` is not modified.
-
 ## Use `uv` in a Slurm job
 
 Declare the training script's dependencies in `pyproject.toml` using `uv add`:
@@ -345,6 +306,133 @@ Submitted batch job 8888888
 the job always uses the pinned dependencies regardless of which compute node
 runs it.
 
+## Install CLI tools with `uv tool`
+
+`uv tool install` installs a package's CLI executables into a persistent,
+isolated environment and adds them to PATH. Use this for command-line tools
+needed across projects — separate from `uv add`, which adds packages imported in
+project code.
+
+### Install a tool
+
+Install `wandb` to access the Weights & Biases CLI:
+
+```bash
+uv tool install wandb
+```
+
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+Resolved 20 packages in 371ms
+Prepared 20 packages in 1.87s
+Installed 20 packages in 2.16s
+ + annotated-types==0.7.0
+ + certifi==2026.2.25
+ [...]
+ + urllib3==2.6.3
+ + wandb==0.25.1
+Installed 2 executables: wandb, wb
+```
+</div>
+
+The `wandb` command is now available system-wide.
+
+### List installed tools
+
+```bash
+uv tool list
+```
+
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+milatools v0.4.1
+- mila
+wandb v0.19.1
+- wandb
+```
+</div>
+
+### Upgrade tools
+
+Upgrade a single tool:
+
+```bash
+uv tool upgrade wandb
+```
+
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+Updated wandb v0.19.1 -> v0.19.2
+Installed 2 executables: wandb, wb
+```
+</div>
+
+Upgrade all installed tools at once:
+
+```bash
+uv tool upgrade --all
+```
+
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+Updated wandb v0.19.1 -> v0.19.2
+```
+</div>
+
+### Uninstall a tool
+
+```bash
+uv tool uninstall wandb
+```
+
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+Uninstalled 1 executable: wandb
+```
+</div>
+
+## Standalone scripts with inline dependencies
+
+For one-off scripts or utilities that do not belong to a project, [PEP
+723](https://peps.python.org/pep-0723/) metadata lets you declare dependencies
+directly inside the script file.
+
+Use `uv add --script` to add dependencies to the script. `uv` will write the `#
+/// script` metadata block automatically:
+
+```bash
+uv add --script experiment.py numpy matplotlib
+```
+
+The resulting script looks like:
+
+```python title="experiment.py"
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#   "matplotlib",
+#   "numpy",
+# ]
+# ///
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+data = np.random.randn(1000)
+plt.hist(data)
+plt.savefig("hist.png")
+```
+
+Run the script with:
+
+```bash
+uv run --script experiment.py
+```
+
+`uv` reads the metadata block, creates a temporary isolated environment with
+those exact dependencies, runs the script, and discards the environment. The
+project's `pyproject.toml` is not modified.
+
 ---
 
 ## Key concepts
@@ -373,6 +461,17 @@ runs it.
 :   A named set of dependencies in `pyproject.toml`. The default development group
     (`--dev`) holds tools like `pytest` that are only needed during local
     development, not when running your research code on the cluster.
+
+`uv tool install`
+:   Installs a CLI tool into a persistent isolated environment and adds its
+    executables to PATH. Use for command-line tools needed across projects
+    (e.g. `wandb`, `mila`). For packages imported in code, use `uv add`
+    instead.
+
+**tool environment**
+:   A persistent isolated virtual environment created by `uv tool install`,
+    stored separately from any project's `.venv`. Removed with
+    `uv tool uninstall`.
 
 **PEP 723 script metadata**
 :   A `# /// script` block at the top of a `.py` file that declares the script's

--- a/docs/userguides/python_uv.md
+++ b/docs/userguides/python_uv.md
@@ -1,0 +1,435 @@
+---
+title: Manage Python Dependencies with uv
+description: >-
+  Set up uv, declare dependencies, and run reproducible Slurm jobs.
+---
+
+# Manage Python Dependencies with `uv`
+
+`uv` is a fast Python package and project manager that consolidates `pip`,
+`virtualenv`, and `pip-tools` into a single tool. This guide covers installing
+`uv` locally and on the cluster, managing project dependencies, running scripts
+reproducibly, and submitting Slurm batch jobs.
+
+## Before you begin
+
+<div class="grid cards" markdown>
+
+-   [:material-server:{ .lg .middle } __Get Started with the Cluster__](../getting_started/index.md)
+    { .card }
+
+    ---
+    Obtain a Mila account, set up MFA, install `uv` and `milatools`, and connect to
+    the cluster for the first time.
+
+&nbsp;
+
+</div>
+
+## What this guide covers
+
+* Install `uv` on a local machine, on the Mila cluster, and on DRAC clusters
+* Create a project and declare dependencies in `pyproject.toml`
+* Add, update, and remove packages
+* Understand how `uv` resolves dependencies safely
+* Reproduce the environment on a new node using `uv.lock`
+* Run standalone scripts with inline dependencies
+* Submit a Slurm job that runs your script with `uv run python`
+* Use `uv` on DRAC clusters
+
+---
+
+## Install `uv`
+
+### On a local machine
+
+Run the following command in a terminal:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+downloading uv 0.10.10 x86_64-unknown-linux-gnu
+no checksums to verify
+installing to /home/username/.local/bin
+  uv
+  uvx
+everything's installed!
+```
+</div>
+
+Verify the installation:
+
+```bash
+uv --version
+```
+
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+uv 0.10.10
+```
+</div>
+
+!!! note "If `uv` is not found"
+    If `uv --version` returns `command not found`, close and reopen your
+    terminal to apply the updated `PATH`.
+
+### On the cluster
+
+Connect to a login node:
+
+```bash
+ssh mila
+```
+
+Then run the install command:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+!!! note "If `uv` is not found"
+    If `uv --version` returns `command not found`, exit the SSH session and
+    reconnect to apply the updated `PATH`.
+
+### On a DRAC cluster
+
+Connect to a DRAC login node, then run the same install command:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+!!! warning "`uv` is not officially supported on DRAC"
+    DRAC does not provide support for `uv`. If you encounter issues using `uv`
+    on a DRAC cluster, contact the Mila IDT team on [Slack or during Office
+    Hours](../help/index.md).
+
+#### Configure `uv` on DRAC
+
+DRAC provides Python through environment modules rather than letting tools
+download their own interpreter. Tell `uv` to prefer the system Python by adding
+the following to `~/.config/uv/uv.toml` on your DRAC account:
+
+```toml title="~/.config/uv/uv.toml"
+python-preference = "system"
+```
+
+This file is read by `uv` whenever it runs on that cluster. Because it lives on
+DRAC's filesystem, it has no effect on your local machine or on the Mila
+cluster.
+
+!!! warning "Load a Python module before running `uv`"
+    With `python-preference = "system"`, `uv` looks for Python in your `PATH`.
+    If no Python module is loaded, `uv` may fail to find the right interpreter.
+    Always run `module load python/3.x` (or the version your project requires)
+    before calling `uv run` or `uv sync` on a DRAC node.
+
+## Create a project
+
+Initialize a new project with a pinned Python version:
+
+```bash
+uv init my-project --python=3.12
+cd my-project
+```
+
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+Initialized project `my-project` at `my-project`
+```
+</div>
+
+The command creates the following files:
+
+```
+my-project/
+├── pyproject.toml    # project metadata and dependencies
+├── .python-version   # pinned Python version
+├── hello.py          # sample entry point
+└── README.md
+```
+
+The virtual environment (`.venv/`) and lockfile (`uv.lock`) are created
+the first time `uv add` or `uv run` is called.
+
+??? tip "Initialize a project in an existing directory"
+    Run `uv init` without a directory name from inside an existing directory to
+    initialize a project in place.
+
+## Manage dependencies
+
+### Add packages
+
+`uv add` installs a package, updates `pyproject.toml`, and synchronizes
+the virtual environment in a single step:
+
+```bash
+uv add torch
+```
+
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+Resolved 7 packages in 1.23s
+Prepared 5 packages in 45.67s
+Installed 5 packages in 1.23s
+ + torch==2.5.1
+```
+</div>
+
+Specify version constraints using PEP 440 syntax:
+
+```bash
+uv add "numpy>=2.0"
+```
+
+### How `uv` resolves dependencies
+
+`pip` installs packages one command at a time and only checks constraints for
+the packages in that command — it can silently break packages that are already
+installed:
+
+> "when you run a `pip` install command, `pip` only considers the packages you
+  are
+> installing in that command, and may break already-installed packages."
+> — [`pip`
+  documentation](https://pip.pypa.io/en/stable/user_guide/#watch-out-for)
+
+`uv add` resolves the **entire dependency graph** before writing anything to
+disk. If adding a new package would conflict with an existing one, `uv` reports
+the conflict and aborts rather than leaving the environment in a broken state.
+
+### Add development dependencies
+
+Development dependencies — testing tools, linters, formatters — are only needed
+during local development, not when running your research code. Add them with
+`--dev`:
+
+```bash
+uv add --dev pytest
+```
+
+### Remove packages
+
+```bash
+uv remove torch
+```
+
+## Reproduce the environment
+
+### Why pin exact versions
+
+Without a lockfile, two installs of the same `pyproject.toml` can produce
+different package versions — a transitive dependency may have released a new
+patch between installs. This can silently change model behaviour or break code
+across nodes and collaborators.
+
+`uv.lock` records the exact resolved version of every dependency, direct and
+transitive. Committing this file to version control guarantees that `uv sync`
+installs a bit-for-bit identical environment on any machine.
+
+### Sync the environment
+
+```bash
+uv sync
+```
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+Resolved 7 packages in 0.08s
+Audited 7 packages in 0.01s
+```
+</div>
+
+!!! tip "Free disk space by clearing the cache"
+    If your home directory is running low on space, first remove stale entries
+    with:
+
+    ```bash
+    uv cache prune
+    ```
+    <div class="result" style="border:None; padding:0" markdown>
+    ``` linenums="0"
+    Pruning cache at: /home/mila/u/username/.cache/uv
+    Removed 21109 files (3.3GiB)
+    ```
+    </div>
+
+    This removes outdated entries while keeping packages still used by your
+    projects. If you need to reclaim more space, remove the entire cache with:
+
+    ```bash
+    uv cache clean
+    ```
+    <div class="result" style="border:None; padding:0" markdown>
+    ``` linenums="0"
+    Clearing cache at: /home/mila/u/username/.cache/uv
+    Cleaning [========>           ] 45%
+    Removed 20518 files (7.1GiB)
+    ```
+    </div>
+
+    `uv` will re-download packages automatically the next time they are needed.
+
+## Run code
+
+### Within a project
+
+`uv run` executes a command inside the project environment. Before running, `uv`
+checks whether the lockfile matches `pyproject.toml` and updates the virtual
+environment if needed. No manual activation of the virtual environment is
+required.
+
+Run a tool registered in the environment:
+
+```bash
+uv run pytest
+```
+
+Run a Python script with the project environment loaded:
+
+```bash
+uv run python train.py
+```
+
+### Standalone scripts with inline dependencies
+
+For one-off scripts or utilities that do not belong to a project, [PEP
+723](https://peps.python.org/pep-0723/) metadata lets you declare dependencies
+directly inside the script file.
+
+Use `uv add --script` to add dependencies to the script. `uv` will write the `#
+/// script` metadata block automatically:
+
+```bash
+uv add --script experiment.py numpy matplotlib
+```
+
+The resulting script looks like:
+
+```python title="experiment.py"
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#   "matplotlib",
+#   "numpy",
+# ]
+# ///
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+data = np.random.randn(1000)
+plt.hist(data)
+plt.savefig("hist.png")
+```
+
+Run the script with:
+
+```bash
+uv run --script experiment.py
+```
+
+`uv` reads the metadata block, creates a temporary isolated environment with
+those exact dependencies, runs the script, and discards the environment. The
+project's `pyproject.toml` is not modified.
+
+## Use `uv` in a Slurm job
+
+Declare the training script's dependencies in `pyproject.toml` using `uv add`:
+
+```bash
+uv add "torch>=2.5"
+```
+
+```python title="train.py"
+import torch
+# ... training code
+```
+
+```bash title="job.sh"
+#!/bin/bash
+#SBATCH --job-name=train
+#SBATCH --ntasks=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=4
+#SBATCH --gpus-per-task=l40s:1
+#SBATCH --mem=16G
+#SBATCH --time=1:00:00
+
+srun uv run python train.py
+```
+
+Submit the job from the project root directory:
+
+```bash
+sbatch job.sh
+```
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+sbatch: --------------------------------------------------------------------------------------------------
+sbatch: # Using default long partition
+sbatch: --------------------------------------------------------------------------------------------------
+Submitted batch job 8888888
+```
+</div>
+
+`uv run` syncs the environment against `uv.lock` before executing `train.py`, so
+the job always uses the pinned dependencies regardless of which compute node
+runs it.
+
+!!! warning "DRAC clusters"
+    `uv run` works the same way on DRAC with two requirements:
+
+    - Set `python-preference = "system"` in `~/.config/uv/uv.toml`
+      (see [Configure `uv` on DRAC](#configure-uv-on-drac)).
+    - Load a Python module in `job.sh` before calling `uv run`:
+
+    ```bash title="job.sh" linenums="10"
+    module load python/3.12
+
+    srun uv run python train.py
+    ```
+
+---
+
+## Key concepts
+
+`pyproject.toml`
+:   The project configuration file. Lists runtime and development dependencies,
+    the required Python version, and project metadata. Updated automatically by
+    `uv add` and `uv remove`.
+
+`uv.lock`
+:   A lockfile generated by `uv` that records the exact resolved version of every
+    dependency. Commit this file to version control to guarantee reproducible
+    environments across nodes and collaborators.
+
+`uv run`
+:   Executes a command inside the project's virtual environment. Use `uv run
+    python <file>` to run a project script. Pass `--script <file>` only for
+    standalone scripts with PEP 723 inline metadata. Syncs the environment
+    against `uv.lock` before running, making manual activation unnecessary.
+
+**virtual environment** (`.venv/`)
+:   An isolated directory containing the Python interpreter and installed packages
+    for the project. Created and managed automatically by `uv`.
+
+**dependency group**
+:   A named set of dependencies in `pyproject.toml`. The default development group
+    (`--dev`) holds tools like `pytest` that are only needed during local
+    development, not when running your research code on the cluster.
+
+`python-preference = "system"` (`~/.config/uv/uv.toml`)
+:   Tells `uv` to prefer a Python interpreter already present on the system (e.g.,
+    loaded via `module load`) rather than downloading its own. Set this once in
+    your DRAC user-level config so every project on that cluster uses the system
+    Python automatically.
+
+**PEP 723 script metadata**
+:   A `# /// script` block at the top of a `.py` file that declares the script's
+    Python version and dependencies. Used for one-off scripts that do not belong
+    to a project. `uv add --script` writes this block automatically; `uv run
+    --script` reads it and creates a temporary isolated environment, leaving
+    `pyproject.toml` unchanged.


### PR DESCRIPTION
## Summary
Adds a new user guide for managing Python dependencies with `uv`, covering installation, project setup, dependency management, Slurm job usage, CLI tools, and standalone scripts. Also polishes description text across Getting Started pages for consistency.

## Changes
- New guide: `docs/userguides/python_uv.md` — comprehensive `uv` reference covering install, `uv add/remove/sync/run`, Slurm jobs, `uv tool`, and PEP 723 inline scripts.
- Linked new guide from `docs/userguides/index.md`, `docs/README.md`, and as a "Next step" card in `train_first_model.md`.
- Refreshed page descriptions in `getting_started/index.md`, `my_first_job.md`, and `train_first_model.md` to be more precise and consistent (e.g. mentioning `mila code`, SSH configuration).