### PR TITLE
Add WandB user guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -107,6 +107,7 @@ If you find any errors in the documentation, missing or unclear sections, or wou
     - [Train Your First Model](getting_started/train_first_model.md)
 - [How-tos and Guides](userguides/index.md)
     - [Manage Python Dependencies with uv](userguides/python_uv.md)
+    - [Track Experiments with Weights & Biases (WandB)](userguides/wandb.md)
     - [Multi-Factor Authentication (MFA) for Cluster Access](Userguide_login_mfa.md)
     - [Logging in to the cluster](userguides/login.md)
     - [Running your code](userguides/running_code.md)

--- a/docs/examples/good_practices/wandb_setup/main.py
+++ b/docs/examples/good_practices/wandb_setup/main.py
@@ -86,7 +86,8 @@ def main():
         # Set the project where this run will be logged
         project="wandb-example",
         name=os.environ.get("SLURM_JOB_ID"),
-        group=os.environ.get("SLURM_ARRAY_JOB_ID", None),
+        id=os.environ.get("SLURM_JOB_ID"),
+        group=os.environ.get("SLURM_ARRAY_JOB_ID"),
         resume="allow",  # See https://docs.wandb.ai/guides/runs/resuming
         tags=["example", "resnet18"],
         # Track hyperparameters and run metadata

--- a/docs/examples/good_practices/wandb_setup/main.py
+++ b/docs/examples/good_practices/wandb_setup/main.py
@@ -5,7 +5,6 @@ import logging
 import os
 import random
 import sys
-import time
 from pathlib import Path
 
 import numpy as np
@@ -91,7 +90,8 @@ def main():
         resume="allow",  # See https://docs.wandb.ai/guides/runs/resuming
         tags=["example", "resnet18"],
         # Track hyperparameters and run metadata
-        config=vars(args),
+        config=vars(args)
+        | {f"env/{k}": v for k, v in os.environ.items() if k.startswith("SLURM")},
     )
     # --8<-- [end:wandb-init]
 
@@ -143,16 +143,7 @@ def main():
         )
 
         # Training loop
-        # t_step_end marks the boundary between the end of the previous compute
-        # step and the start of the next data load. On the first iteration this
-        # captures any overhead before the loop begins.
-        t_step_end = time.perf_counter()
         for batch in train_dataloader:
-            # The dataloader has already fetched the batch by the time we reach
-            # here, so the elapsed time since t_step_end is the data-load wait.
-            t_data_load_end = time.perf_counter()
-            data_load_s = t_data_load_end - t_step_end
-
             # Move the batch to the GPU before we pass it to the model
             batch = tuple(item.to(device) for item in batch)
             x, y = batch
@@ -166,9 +157,6 @@ def main():
             loss.backward()
             optimizer.step()
 
-            t_step_end = time.perf_counter()
-            compute_s = t_step_end - t_data_load_end
-
             # Calculate some metrics:
             n_correct_predictions = logits.detach().argmax(-1).eq(y).sum()
             n_samples = y.shape[0]
@@ -178,16 +166,14 @@ def main():
             logger.debug(f"Average Loss: {loss.item()}")
 
             # Log metrics with wandb
-            # --8<-- [start:wandb-log-train-perf]
+            # --8<-- [start:wandb-log-train]
             wandb.log(
                 {
                     "train/accuracy": accuracy,
                     "train/loss": loss,
-                    "perf/data_load_s": data_load_s,
-                    "perf/compute_s": compute_s,
                 }
             )
-            # --8<-- [end:wandb-log-train-perf]
+            # --8<-- [end:wandb-log-train]
 
             # Advance the progress bar one step and update the progress bar text.
             progress_bar.update(1)

--- a/docs/examples/good_practices/wandb_setup/main.py
+++ b/docs/examples/good_practices/wandb_setup/main.py
@@ -5,6 +5,7 @@ import logging
 import os
 import random
 import sys
+import time
 from pathlib import Path
 
 import numpy as np
@@ -80,14 +81,18 @@ def main():
     # This specific example here does not do that.
 
     # Setup Wandb
+    # --8<-- [start:wandb-init]
     wandb.init(
         # Set the project where this run will be logged
         project="wandb-example",
         name=os.environ.get("SLURM_JOB_ID"),
+        group=os.environ.get("SLURM_ARRAY_JOB_ID", None),
         resume="allow",  # See https://docs.wandb.ai/guides/runs/resuming
+        tags=["example", "resnet18"],
         # Track hyperparameters and run metadata
         config=vars(args),
     )
+    # --8<-- [end:wandb-init]
 
     # Create a model and move it to the GPU.
     model = resnet18(num_classes=10)
@@ -137,7 +142,16 @@ def main():
         )
 
         # Training loop
+        # t_step_end marks the boundary between the end of the previous compute
+        # step and the start of the next data load. On the first iteration this
+        # captures any overhead before the loop begins.
+        t_step_end = time.perf_counter()
         for batch in train_dataloader:
+            # The dataloader has already fetched the batch by the time we reach
+            # here, so the elapsed time since t_step_end is the data-load wait.
+            t_data_load_end = time.perf_counter()
+            data_load_s = t_data_load_end - t_step_end
+
             # Move the batch to the GPU before we pass it to the model
             batch = tuple(item.to(device) for item in batch)
             x, y = batch
@@ -151,6 +165,9 @@ def main():
             loss.backward()
             optimizer.step()
 
+            t_step_end = time.perf_counter()
+            compute_s = t_step_end - t_data_load_end
+
             # Calculate some metrics:
             n_correct_predictions = logits.detach().argmax(-1).eq(y).sum()
             n_samples = y.shape[0]
@@ -160,7 +177,16 @@ def main():
             logger.debug(f"Average Loss: {loss.item()}")
 
             # Log metrics with wandb
-            wandb.log({"train/accuracy": accuracy, "train/loss": loss})
+            # --8<-- [start:wandb-log-train-perf]
+            wandb.log(
+                {
+                    "train/accuracy": accuracy,
+                    "train/loss": loss,
+                    "perf/data_load_s": data_load_s,
+                    "perf/compute_s": compute_s,
+                }
+            )
+            # --8<-- [end:wandb-log-train-perf]
 
             # Advance the progress bar one step and update the progress bar text.
             progress_bar.update(1)
@@ -171,7 +197,19 @@ def main():
         logger.info(
             f"Epoch {epoch}: Val loss: {val_loss:.3f} accuracy: {val_accuracy:.2%}"
         )
+        # --8<-- [start:wandb-log-val]
+        wandb.log(
+            {
+                "val/accuracy": val_accuracy,
+                "val/loss": val_loss,
+                "epoch": epoch,
+            }
+        )
+        # --8<-- [end:wandb-log-val]
 
+    # --8<-- [start:wandb-finish]
+    wandb.finish()
+    # --8<-- [end:wandb-finish]
     print("Done!")
 
 

--- a/docs/getting_started/train_first_model.md
+++ b/docs/getting_started/train_first_model.md
@@ -193,14 +193,14 @@ The output will confirm the submission of the job (e.g. `Submitted batch job
 
 <div class="grid cards" markdown>
 
--   [:material-run-fast:{ .lg .middle } __Manage Python Dependencies with `uv`__](../userguides/python_uv.md)
+-   [:material-language-python:{ .lg .middle } __Manage Python Dependencies with `uv`__](../userguides/python_uv.md)
     { .card }
 
     ---
     Install uv, manage project dependencies, run reproducible Slurm jobs, and run
     standalone scripts.
 
--   [:material-run-fast:{ .lg .middle } __Track Experiments with WandB__](../userguides/wandb.md)
+-   [:material-trending-up:{ .lg .middle } __Track Experiments with WandB__](../userguides/wandb.md)
     { .card }
 
     ---

--- a/docs/getting_started/train_first_model.md
+++ b/docs/getting_started/train_first_model.md
@@ -207,6 +207,4 @@ The output will confirm the submission of the job (e.g. `Submitted batch job
     Set up WandB and follow best practices for logging experiments, organizing
     runs, and diagnosing bottlenecks on the cluster.
 
-&nbsp;
-
 </div>

--- a/docs/getting_started/train_first_model.md
+++ b/docs/getting_started/train_first_model.md
@@ -200,6 +200,13 @@ The output will confirm the submission of the job (e.g. `Submitted batch job
     Install uv, manage project dependencies, run reproducible Slurm jobs, and run
     standalone scripts.
 
+-   [:material-run-fast:{ .lg .middle } __Track Experiments with WandB__](../userguides/wandb.md)
+    { .card }
+
+    ---
+    Set up WandB and follow best practices for logging experiments, organizing
+    runs, and diagnosing bottlenecks on the cluster.
+
 &nbsp;
 
 </div>

--- a/docs/userguides/index.md
+++ b/docs/userguides/index.md
@@ -5,6 +5,7 @@ Check out our guides picturing different ways to use the cluster:
 | Guide | Quick description |
 | ----- | ----------------- |
 | [Manage Python Dependencies with uv](../userguides/python_uv.md) | Set up uv to manage project dependencies |
+| [Track Experiments with Weights & Biases (WandB)](../userguides/wandb) | Log metrics, organize runs, and run sweeps on the Mila cluster |
 | [Multi-Factor authentication](../Userguide_login_mfa) | Use MFA to access the Mila cluster |
 | [Logging in to the cluster](../userguides/login) | Log in to the Mila cluster |
 | [Running your code](../userguides/running_code.md) | Run your code on the cluster |

--- a/docs/userguides/python_uv.md
+++ b/docs/userguides/python_uv.md
@@ -479,3 +479,18 @@ project's `pyproject.toml` is not modified.
     to a project. `uv add --script` writes this block automatically; `uv run
     --script` reads it and creates a temporary isolated environment, leaving
     `pyproject.toml` unchanged.
+
+## Next step
+
+<div class="grid cards" markdown>
+
+-   [:material-run-fast:{ .lg .middle } __Track Experiments with WandB__](../userguides/wandb.md)
+    { .card }
+
+    ---
+    Set up WandB and follow best practices for logging experiments, organizing
+    runs, and diagnosing bottlenecks on the cluster.
+
+&nbsp;
+
+</div>

--- a/docs/userguides/python_uv.md
+++ b/docs/userguides/python_uv.md
@@ -16,7 +16,7 @@ reproducibly, and submitting Slurm batch jobs.
 
 <div class="grid cards" markdown>
 
--   [:material-server:{ .lg .middle } __Get Started with the Cluster__](../getting_started/index.md)
+-   [:material-run-fast:{ .lg .middle } __Get Started with the Cluster__](../getting_started/index.md)
     { .card }
 
     ---
@@ -484,7 +484,7 @@ project's `pyproject.toml` is not modified.
 
 <div class="grid cards" markdown>
 
--   [:material-run-fast:{ .lg .middle } __Track Experiments with WandB__](../userguides/wandb.md)
+-   [:material-trending-up:{ .lg .middle } __Track Experiments with WandB__](../userguides/wandb.md)
     { .card }
 
     ---

--- a/docs/userguides/wandb.md
+++ b/docs/userguides/wandb.md
@@ -22,7 +22,7 @@ wandb.ai for team-level project visibility and collaboration.
     ---
     Train your first ResNet18 model on CIFAR-10 on a single GPU using `sbatch`.
 
--   [:material-run-fast:{ .lg .middle } __Manage Python Dependencies with `uv`__](../userguides/python_uv.md)
+-   [:material-language-python:{ .lg .middle } __Manage Python Dependencies with `uv`__](../userguides/python_uv.md)
     { .card }
 
     ---

--- a/docs/userguides/wandb.md
+++ b/docs/userguides/wandb.md
@@ -150,20 +150,24 @@ import wandb
 wandb.init(
     project="wandb-example",                # (1)!
     name=os.environ.get("SLURM_JOB_ID"),    # (2)!
-    id=os.environ.get("SLURM_JOB_ID"),
-    resume="allow",                         # (3)!
-    config=vars(args) | {f"env/{k}": v for k, v in os.environ.items() if k.startswith("SLURM"},    # (4)!
+    id=os.environ.get("SLURM_JOB_ID"),      # (3)!
+    resume="allow",                         # (4)!
+    config=vars(args)
+    | {f"env/{k}": v for k, v in os.environ.items() if k.startswith("SLURM")},  # (5)!
 )
 ```
 { .annotate }
 
 1. Groups runs in the WandB UI. Use one project per research question.
-2. Links the run to its log file (`slurm-<JOBID>.out`) for easy
-   cross-referencing.
-3. Creates a new run if the ID does not exist, or resumes it if it does. Useful
+2. Human-readable display name shown in the WandB Runs table.
+3. Sets the unique run ID. `resume="allow"` uses this to find and resume the run
+   if it was preempted. Setting it to the Slurm job ID also links the run to its
+   log file (`slurm-<JOBID>.out`).
+4. Creates a new run if the ID does not exist, or resumes it if it does. Useful
    when combined with checkpointing to recover from preemption.
-4. Pass the full `argparse` namespace and SLURM environment variables for easier debugging.
-    Every key becomes a searchable, filterable column in the WandB Runs table under **Config**.
+5. Pass the full `argparse` namespace and SLURM environment variables for easier
+   debugging. Every key becomes a searchable, filterable column in the WandB
+   Runs table under **Config**.
 
 ### Log metrics
 
@@ -212,15 +216,17 @@ wandb.init(
     project="wandb-example",
     name=os.environ.get("SLURM_JOB_ID"),
     id=os.environ.get("SLURM_JOB_ID"),
-    group=os.environ.get("SLURM_ARRAY_JOB_ID"),   # (1)!
+    group=os.environ.get("SLURM_ARRAY_JOB_ID"),     # (1)!
     resume="allow",
-    tags=["example", "resnet18"],                       # (2)!
-    config=vars(args),
+    tags=["example", "resnet18"],                   # (2)!
+    config=vars(args)
+    | {f"env/{k}": v for k, v in os.environ.items() if k.startswith("SLURM")},
 )
 ```
 { .annotate }
 
-1. Using `SLURM_ARRAY_JOB_ID` automatically as the group clusters all jobs into a single expandable row.
+1. Using `SLURM_ARRAY_JOB_ID` automatically as the group clusters all jobs into
+   a single expandable row.
 2. Labels runs for filtering in the Runs table.
 
 ## Diagnose training bottlenecks
@@ -242,42 +248,6 @@ Two patterns indicate different root causes:
 - **Low or oscillating utilization** — the GPU idles while waiting for the next
   batch. The data pipeline cannot deliver batches fast enough; the job is
   I/O-bound.
-
-### Add step timing metrics
-
-GPU utilization alone confirms that a bottleneck exists but does not show where
-time is lost. Log data-loading time and compute time separately to quantify each
-phase:
-
-```python
-import time
-
-# Before the batch loop:
-t_step_end = time.perf_counter()
-
-for batch in train_dataloader:
-    # The dataloader has already fetched the batch by the time the loop body
-    # starts, so the elapsed time since t_step_end is the data-load wait.
-    t_data_load_end = time.perf_counter()
-    data_load_s = t_data_load_end - t_step_end
-
-    # forward pass, loss computation, backward pass, optimizer step
-
-    t_step_end = time.perf_counter()
-    compute_s = t_step_end - t_data_load_end
-
-    wandb.log(
-        {
-            "train/loss": loss,
-            "train/accuracy": accuracy,
-            "perf/data_load_s": data_load_s,
-            "perf/compute_s": compute_s,
-        }
-    )
-```
-
-When `perf/data_load_s` is consistently larger than `perf/compute_s`, the job is
-I/O-bound.
 
 !!! tip
     Common fixes for an I/O bottleneck: increase `num_workers` in the
@@ -312,12 +282,14 @@ integration:
 
 `wandb.init()`
 :   Starts a WandB run. The most commonly used arguments are `project`, `name`,
-    `group`, `config` and `resume`.
+    `id`, `group`, `config` and `resume`.
 
 `config=` (in `wandb.init()`)
 :   Stores a dictionary of hyperparameters alongside the run. Each key becomes a
     searchable, filterable column in the WandB Runs table. Pass
-    `config=vars(args)` to capture the full `argparse` namespace automatically.
+    `config=vars(args) | {f"env/{k}": v for k, v in os.environ.items() if
+    k.startswith("SLURM")}` to capture the full `argparse` namespace and Slurm
+    environment variables for easier debugging.
 
 `group=` (in `wandb.init()`)
 :   Groups related runs under a single expandable row in the WandB Runs table.

--- a/docs/userguides/wandb.md
+++ b/docs/userguides/wandb.md
@@ -281,6 +281,10 @@ integration:
     --8<-- "docs/examples/good_practices/wandb_setup/pyproject.toml"
     ```
 
+!!! tip "Example run"
+    Running these scripts produces a run like this
+    [wandb-example run](https://wandb.ai/lebrice/wandb-example).
+
 ---
 
 ## Key concepts

--- a/docs/userguides/wandb.md
+++ b/docs/userguides/wandb.md
@@ -1,0 +1,341 @@
+---
+title: Track Experiments with Weights & Biases (WandB)
+description: >-
+  Set up WandB and follow best practices for logging experiments, organizing
+  runs, and diagnosing bottlenecks on the cluster.
+---
+
+# Track Experiments with Weights & Biases (WandB)
+
+[Weights & Biases](https://wandb.ai) is an experiment tracking platform for
+logging metrics, hyperparameters, and artifacts from training runs. Mila members
+supervised by core professors can access the shared Mila organization on
+wandb.ai for team-level project visibility and collaboration.
+
+## Before you begin
+
+<div class="grid cards" markdown>
+
+-   [:material-run-fast:{ .lg .middle } __Train Your First Model__](../getting_started/train_first_model.md)
+    { .card }
+
+    ---
+    Train your first ResNet18 model on CIFAR-10 on a single GPU using `sbatch`.
+
+&nbsp;
+
+</div>
+
+!!! success "Request access to the Mila WandB organization"
+    Students supervised by core professors are eligible for the Mila
+    organization on wandb.ai. Write to
+    [it-support@mila.quebec](mailto:it-support@mila.quebec) to request access.
+
+## What this guide covers
+
+* Sign in with single sign-on (SSO) using your `@mila.quebec` address.
+* Authenticate the WandB CLI on the cluster.
+* Initialize a run and log metrics in a training script.
+* Name runs, attach tags, and group related runs.
+* Configure Slurm job scripts for reliable WandB logging and run resumption.
+* Identify whether a training job is I/O-bound or compute-bound using
+  WandB system metrics and step timing.
+
+---
+
+## Sign in for the first time
+
+WandB uses Mila's SSO provider. Signing in with your `@mila.quebec` address the
+first time links the account to the Mila organization.
+
+### Migrate an existing WandB account
+
+!!! warning "Add your Mila email first to avoid a duplicate account"
+    To avoid creating a duplicate account: add your `@mila.quebec` address to
+    the existing WandB account and make it the primary email **before**
+    following the steps below. See the WandB documentation on [managing email
+    addresses](https://docs.wandb.ai/guides/app/settings-page/emails). Then log
+    out from WandB before proceeding.
+
+1. Go to [wandb.ai](https://wandb.ai) and click **Sign in**.
+2. Enter your `@mila.quebec` email address. The password field will disappear
+   once a recognized SSO domain is detected.
+3. Click **Log in** — the browser will redirect you to the Mila SSO page.
+4. Select the **mila.quebec** identity provider. WandB will offer to link the
+   existing account to the Mila organization.
+
+### Create a new account
+
+Follow the same SSO steps above. At the account creation prompt, select
+**Professional**.
+
+??? question "Which account type to select?"
+    Select **Professional** at the account creation prompt. This unlocks team
+    features required for the Mila organization. The Mila IT team manages
+    organization-level billing, so no personal plan upgrade is required.
+
+## Authenticate the CLI on the cluster
+
+Most WandB Python API calls require a valid API key stored in the environment.
+
+### Log in interactively
+
+Install WandB as a tool on a login node, then authenticate:
+
+```bash
+uv tool install --upgrade wandb
+wandb login
+```
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+Resolved 20 packages in 371ms
+Prepared 20 packages in 1.87s
+Installed 20 packages in 2.16s
+ + annotated-types==0.7.0
+ + certifi==2026.2.25
+ [...]
+ + urllib3==2.6.3
+ + wandb==0.25.1
+Installed 2 executables: wandb, wb
+wandb: Logging into https://api.wandb.ai.
+wandb: Create a new API key at: https://wandb.ai/authorize?ref=models
+wandb: Store your API key securely and do not share it.
+wandb: Paste your API key and hit enter:
+wandb: Appending key for api.wandb.ai to your netrc file: /home/mila/u/username/.netrc
+wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
+```
+</div>
+
+!!! tip
+    `uv tool install --upgrade wandb` is a one-time step per cluster. The API
+    key is stored in `~/.netrc` after `wandb login`; subsequent jobs do not need
+    to re-run `wandb login` unless the key is rotated.
+
+### Offline mode
+
+On clusters without outbound internet access on compute nodes, run in offline
+mode and sync after the job completes:
+
+```bash
+export WANDB_MODE=offline
+srun uv run python main.py
+```
+
+After the job finishes, sync the run from the login node:
+
+```bash
+wandb sync --sync-all
+```
+
+!!! tip
+    On DRAC clusters, loading the `httpproxy` module before the `srun` line is
+    an alternative to offline mode:
+    ```bash
+    module load httpproxy
+    srun uv run python main.py
+    ```
+
+## Initialize and log a training run
+
+Every WandB run starts with `wandb.init()`. Call `wandb.finish()` at the end of
+the script — it is called automatically at exit, but an explicit call is safer
+in Slurm jobs.
+
+### Initialize a run
+
+```python
+import os
+import wandb
+
+wandb.init(
+    project="wandb-example",                # (1)!
+    name=os.environ.get("SLURM_JOB_ID"),    # (2)!
+    resume="allow",                         # (3)!
+    config=vars(args),                      # (4)!
+)
+```
+{ .annotate }
+
+1. Groups runs in the WandB UI. Use one project per research question.
+2. Links the run to its log file (`slurm-<JOBID>.out`) for easy
+   cross-referencing.
+3. Creates a new run if the ID does not exist, or resumes it if it does. Useful
+   when combined with checkpointing to recover from preemption.
+4. Pass the full `argparse` namespace — every key becomes a searchable,
+   filterable column in the WandB Runs table under **Config**.
+
+### Log metrics
+
+Call `wandb.log()` inside the batch loop to record training metrics at each
+step:
+
+```python
+wandb.log(
+    {
+        "train/accuracy": accuracy,
+        "train/loss": loss
+    }
+)
+```
+
+Log validation metrics once per epoch, after the validation loop:
+
+```python
+wandb.log(
+    {
+        "val/accuracy": val_accuracy,
+        "val/loss": val_loss,
+        "epoch": epoch
+    }
+)
+```
+
+!!! tip
+    Prefix metric names with `train/` and `val/`. WandB groups metrics with
+    matching prefixes automatically in the Charts panel.
+
+!!! tip "Complete example"
+    See the [WandB setup
+    example](../examples/good_practices/wandb_setup/index.md) for a complete
+    single-GPU training script with WandB logging integrated.
+
+## Organize runs
+
+Three arguments help keep runs organized as a project grows. `name=` and `tags=`
+make individual runs easy to identify and filter in the Runs table, while
+`group=` clusters related runs — such as multi-seed runs or ablations — under a
+single expandable row.
+
+```python
+wandb.init(
+    project="wandb-example",
+    name=os.environ.get("SLURM_JOB_ID"),
+    group=os.environ.get("SLURM_ARRAY_JOB_ID", None),   # (1)!
+    resume="allow",
+    tags=["example", "resnet18"],                       # (2)!
+    config=vars(args),
+)
+```
+{ .annotate }
+
+1. Clusters multi-seed under a single expandable row. Passing
+   `SLURM_ARRAY_JOB_ID` groups every task in a job array together automatically.
+2. Labels runs for filtering in the Runs table.
+
+## Diagnose training bottlenecks
+
+WandB records GPU utilization, CPU usage, and memory under the **System** tab of
+every run automatically — no extra code required. These metrics are the first
+place to check when a training job is slower than expected.
+
+### Read system metrics
+
+Open a run in the WandB UI and select the **System** tab. The **GPU
+Utilization** chart shows the fraction of time the GPU spent on active compute
+during each sampling interval.
+
+Two patterns indicate different root causes:
+
+- **Sustained utilization near 100%** — the job is compute-bound. The GPU is the
+  bottleneck; this is the expected state for well-configured training.
+- **Low or oscillating utilization** — the GPU idles while waiting for the next
+  batch. The data pipeline cannot deliver batches fast enough; the job is
+  I/O-bound.
+
+### Add step timing metrics
+
+GPU utilization alone confirms that a bottleneck exists but does not show where
+time is lost. Log data-loading time and compute time separately to quantify each
+phase:
+
+```python
+import time
+
+# Before the batch loop:
+t_step_end = time.perf_counter()
+
+for batch in train_dataloader:
+    # The dataloader has already fetched the batch by the time the loop body
+    # starts, so the elapsed time since t_step_end is the data-load wait.
+    t_data_load_end = time.perf_counter()
+    data_load_s = t_data_load_end - t_step_end
+
+    # forward pass, loss computation, backward pass, optimizer step
+
+    t_step_end = time.perf_counter()
+    compute_s = t_step_end - t_data_load_end
+
+    wandb.log(
+        {
+            "train/loss": loss,
+            "train/accuracy": accuracy,
+            "perf/data_load_s": data_load_s,
+            "perf/compute_s": compute_s,
+        }
+    )
+```
+
+When `perf/data_load_s` is consistently larger than `perf/compute_s`, the job is
+I/O-bound.
+
+!!! tip
+    Common fixes for an I/O bottleneck: increase `num_workers` in the
+    `DataLoader`, enable `pin_memory=True`, or copy the dataset to
+    `$SLURM_TMPDIR` before the job starts.
+
+## Full job scripts
+
+The [`wandb_setup` example](../examples/good_practices/wandb_setup/index.md)
+provides a complete job script and training script with data staging and WandB
+integration:
+
+=== "job.sh"
+    ```bash title="job.sh"
+    --8<-- "docs/examples/good_practices/wandb_setup/job.sh"
+    ```
+
+=== "main.py"
+    ```python title="main.py"
+    --8<-- "docs/examples/good_practices/wandb_setup/main.py"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml title="pyproject.toml"
+    --8<-- "docs/examples/good_practices/wandb_setup/pyproject.toml"
+    ```
+
+---
+
+## Key concepts
+
+`wandb.init()`
+:   Starts a WandB run. The most commonly used arguments are `project`, `name`,
+    `group`, `config` and `resume`.
+
+`config=` (in `wandb.init()`)
+:   Stores a dictionary of hyperparameters alongside the run. Each key becomes a
+    searchable, filterable column in the WandB Runs table. Pass
+    `config=vars(args)` to capture the full `argparse` namespace automatically.
+
+`group=` (in `wandb.init()`)
+:   Groups related runs under a single expandable row in the WandB Runs table.
+    Useful for multi-seed runs or ablations. Pass `SLURM_ARRAY_JOB_ID` to group
+    all tasks in a job array automatically.
+
+`wandb.log()`
+:   Records a dictionary of metric values at the current step. Call once per
+    iteration or epoch.
+
+`WANDB_MODE`
+:   Controls logging mode. Set to `offline` on clusters without outbound internet
+    access. Sync with `wandb sync --sync-all` after the job completes.
+
+System metrics
+:   GPU utilization, CPU usage, and memory stats collected automatically by WandB
+    during a run. Visible under the **System** tab of a run in the WandB UI.
+
+`perf/` prefix
+:   Convention for logging performance timing metrics (e.g., `perf/data_load_s`,
+    `perf/compute_s`) separately from training metrics to support bottleneck
+    diagnosis.

--- a/docs/userguides/wandb.md
+++ b/docs/userguides/wandb.md
@@ -118,7 +118,7 @@ mode and sync after the job completes:
 
 ```bash
 export WANDB_MODE=offline
-srun uv run python main.py
+srun uv run --offline python main.py
 ```
 
 After the job finishes, sync the run from the login node:
@@ -150,8 +150,9 @@ import wandb
 wandb.init(
     project="wandb-example",                # (1)!
     name=os.environ.get("SLURM_JOB_ID"),    # (2)!
+    id=os.environ.get("SLURM_JOB_ID"),
     resume="allow",                         # (3)!
-    config=vars(args),                      # (4)!
+    config=vars(args) | {f"env/{k}": v for k, v in os.environ.items() if k.startswith("SLURM"},    # (4)!
 )
 ```
 { .annotate }
@@ -161,8 +162,8 @@ wandb.init(
    cross-referencing.
 3. Creates a new run if the ID does not exist, or resumes it if it does. Useful
    when combined with checkpointing to recover from preemption.
-4. Pass the full `argparse` namespace — every key becomes a searchable,
-   filterable column in the WandB Runs table under **Config**.
+4. Pass the full `argparse` namespace and SLURM environment variables for easier debugging.
+    Every key becomes a searchable, filterable column in the WandB Runs table under **Config**.
 
 ### Log metrics
 
@@ -210,7 +211,8 @@ single expandable row.
 wandb.init(
     project="wandb-example",
     name=os.environ.get("SLURM_JOB_ID"),
-    group=os.environ.get("SLURM_ARRAY_JOB_ID", None),   # (1)!
+    id=os.environ.get("SLURM_JOB_ID"),
+    group=os.environ.get("SLURM_ARRAY_JOB_ID"),   # (1)!
     resume="allow",
     tags=["example", "resnet18"],                       # (2)!
     config=vars(args),
@@ -218,14 +220,13 @@ wandb.init(
 ```
 { .annotate }
 
-1. Clusters multi-seed under a single expandable row. Passing
-   `SLURM_ARRAY_JOB_ID` groups every task in a job array together automatically.
+1. Using `SLURM_ARRAY_JOB_ID` automatically as the group clusters all jobs into a single expandable row.
 2. Labels runs for filtering in the Runs table.
 
 ## Diagnose training bottlenecks
 
 WandB records GPU utilization, CPU usage, and memory under the **System** tab of
-every run automatically — no extra code required. These metrics are the first
+every run automatically, no extra code is required. These metrics are the first
 place to check when a training job is slower than expected.
 
 ### Read system metrics

--- a/docs/userguides/wandb.md
+++ b/docs/userguides/wandb.md
@@ -22,7 +22,12 @@ wandb.ai for team-level project visibility and collaboration.
     ---
     Train your first ResNet18 model on CIFAR-10 on a single GPU using `sbatch`.
 
-&nbsp;
+-   [:material-run-fast:{ .lg .middle } __Manage Python Dependencies with `uv`__](../userguides/python_uv.md)
+    { .card }
+
+    ---
+    Install uv, manage project dependencies, run reproducible Slurm jobs, and run
+    standalone scripts.
 
 </div>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ test = [
     "setuptools>=80.9.0",
 ]
 
+[tool.setuptools]
+packages = []
+
 [tool.hatch.envs.default]
 installer = "uv"
 dependency-groups = ["dev"]

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -338,7 +338,8 @@ def filter_job_output_before_regression_check(
         "Date:",
         "Hostname:",
         "INFO:__main__:",
-        "warning:"
+        "warning:",
+        "wandb:",
     ),
     regex_substitutions: dict[str, str] = None,
     # line_matches: Sequence[str] = ("INFO:__main__:Epoch", "accuracy:"),


### PR DESCRIPTION
## Summary
Adds a new user guide for tracking experiments with Weights & Biases on the Mila cluster, covering SSO sign-in, CLI authentication, run initialization, metric logging, run organization, and I/O bottleneck diagnosis. Also updates the WandB example script with step timing, run grouping, and code snippet markers.

## Changes
- New `docs/userguides/wandb.md` guide covering SSO sign-in, CLI auth, `wandb.init()`, `wandb.log()`, run organization with `group=`/`tags=`, and bottleneck diagnosis using `perf/data_load_s` and `perf/compute_s` metrics.
- Updated `docs/examples/good_practices/wandb_setup/main.py` with step timing metrics, `group=`/`tags=` in `wandb.init()`, explicit `wandb.finish()`, validation logging, and `--8<--` code snippet markers for embedding in the guide.
- Added WandB guide entry to `docs/README.md` table of contents and `docs/userguides/index.md` table.
- Added "Track Experiments with WandB" next-step card to `docs/getting_started/train_first_model.md`.
- Minor copy improvements across Getting Started pages (description text and card labels).