### PR TITLE
Add file required for docmetrics comment (#357)

### DIFF
--- a/.github/workflows/docmetrics-comment.yml
+++ b/.github/workflows/docmetrics-comment.yml
@@ -1,0 +1,17 @@
+name: Post DocMetrics PR comment
+
+on:
+  workflow_run:
+    workflows: [build_test]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  post-comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    uses: mila-iqia/docmetrics/.github/workflows/post-pr-comment.yml@v0.0.7
+    with:
+      run-id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
It seems likely that this file needs to be present in the master branch before the comment from docmetrics (see PR #358) can properly show up in the PRs. I don't know if there is another workaround, I have not done that much investigation. Hopefully this works, and worst case I'll make another PR to revert this change.