### PR TITLE
Add Claude Code and Mila Skills setup guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,9 +36,9 @@ recommend you start by checking out the [short quick start guide](getting_starte
 
     ---
 
-    Coming soon!
+    Powercharge your workflow with AI coding tools tailored for Mila researchers
 
-    Powercharge your AI agent with curated resources
+    [:octicons-arrow-right-24: Explore AI agents](ai)
 
 
 -   :material-book-open-page-variant:{ .lg .middle } __Technical reference__
@@ -131,6 +131,8 @@ If you find any errors in the documentation, missing or unclear sections, or wou
         - [Advanced Examples](examples/advanced/index.md)
             - [Multi-Node / Multi-GPU ImageNet Training](examples/advanced/imagenet/index.md)
 - [AI agents](ai/index.md)
+    - [Set Up Claude Code](ai/claude_code.md)
+    - [Install Mila Skills for Claude Code](ai/mila_skills.md)
 - [Technical reference](technical_reference/index.md)
     - [Cheatsheet](technical_reference/cheatsheet.md)
     - [Glossary](technical_reference/glossary.md)

--- a/docs/ai/claude_code.md
+++ b/docs/ai/claude_code.md
@@ -1,0 +1,355 @@
+---
+title: Set Up Claude Code
+description: >-
+  Install Claude Code and extend Claude Code with skills from a marketplace.
+---
+
+# Set Up Claude Code
+
+Claude Code is Anthropic's official command-line interface for Claude.
+It brings an AI coding assistant directly into the terminal, desktop, or
+IDE, enabling researchers to generate code, explain errors, and automate
+repetitive tasks without leaving their development environment. This guide
+covers installation, authentication, and skills — reusable extensions that
+add domain-specific behavior to Claude Code.
+
+## Before you begin
+
+!!! success "Requirements"
+    - An [Anthropic account](https://claude.ai) with an active Claude Pro,
+      Team, or Enterprise subscription.
+    - macOS, Linux, or [Windows with WSL2
+      configured](../getting_started/index.md#install-wsl) (for CLI
+      installation).
+
+## What this guide covers
+
+* Install Claude Code using the CLI installer, desktop app,
+  or IDE extension
+* Authenticate with an Anthropic account
+* Install skills from a skills marketplace
+
+---
+
+## Install Claude Code
+
+Claude Code is available as a command-line tool and as an extension for VS Code.
+
+=== "CLI (macOS / Linux)"
+
+    Run the installer in a terminal:
+
+    ```bash
+    curl -fsSL https://claude.ai/install.sh | bash
+    ```
+    <div class="result" style="border:None; padding:0" markdown>
+    ``` linenums="0"
+    Setting up Claude Code...
+
+    ✔ Claude Code successfully installed!
+
+      Version: 2.1.109
+
+      Location: ~/.local/bin/claude
+
+
+      Next: Run claude --help to get started
+
+    ✅ Installation complete!
+    ```
+    </div>
+
+    Verify the installation:
+
+    ```bash
+    claude --version
+    ```
+    <div class="result" style="border:None; padding:0" markdown>
+    ``` linenums="0"
+    2.1.109 (Claude Code)
+    ```
+    </div>
+
+=== "CLI (Windows — WSL2)"
+
+    ???+ warning "WSL2 required"
+        The CLI installer requires a Linux environment. Install and configure
+        WSL2 before continuing. See [Getting Started — Install
+        WSL](../getting_started/index.md#install-wsl).
+
+    Open a WSL2 terminal and run the installer:
+
+    ```bash
+    curl -fsSL https://claude.ai/install.sh | bash
+    ```
+    <div class="result" style="border:None; padding:0" markdown>
+    ``` linenums="0"
+    Setting up Claude Code...
+
+    ✔ Claude Code successfully installed!
+
+      Version: 2.1.109
+
+      Location: ~/.local/bin/claude
+
+
+      Next: Run claude --help to get started
+
+    ✅ Installation complete!
+    ```
+    </div>
+
+    Verify the installation:
+
+    ```bash
+    claude --version
+    ```
+    <div class="result" style="border:None; padding:0" markdown>
+    ``` linenums="0"
+    2.1.109 (Claude Code)
+    ```
+    </div>
+
+=== "IDE extension"
+
+    Install the Claude Code extension from the marketplace for the IDE:
+
+    - **VS Code** — search for "Claude Code" in the [VS Code
+      Marketplace](https://marketplace.visualstudio.com/)
+
+!!! note
+    For the most up-to-date installation instructions, see the [Claude Code
+    product page](https://claude.com/product/claude-code).
+
+## Authenticate
+
+After installation, launch Claude Code to complete authentication.
+
+For the CLI, open a terminal and run:
+
+```bash
+claude
+```
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+ ▐▛███▜▌   Claude Code v2.1.109
+▝▜█████▛▘  Sonnet 4.6 · Claude Team
+  ▘▘ ▝▝    ~/CODE/project
+
+--------------------------------------------------------------------------------
+  Login
+
+
+   Claude Code can be used with your Claude subscription or billed based on API
+   usage through your Console account.
+
+   Select login method:
+
+   ❯1. Claude account with subscription · Pro, Max, Team, or Enterprise
+
+    2. Anthropic Console account · API usage billing
+
+    3. 3rd-party platform · Amazon Bedrock, Microsoft Foundry, or Vertex AI
+
+
+  Esc to cancel
+```
+</div>
+
+Claude Code opens a browser window. Complete the Anthropic login flow in the
+browser; the terminal session authenticates automatically when login succeeds.
+The desktop app and IDE extensions display a built-in login prompt on first
+launch.
+
+## Install skills from a marketplace
+
+Skills extend Claude Code with reusable, domain-specific behavior. Each skill is
+a self-contained workflow invoked as a slash command — for example,
+`/code-review` or `/skill-creator`. Skills are distributed through
+GitHub-hosted marketplaces and can be installed into any Claude Code session.
+
+### Add a marketplace
+
+Skills marketplaces are GitHub repositories containing skill definitions.
+Register a marketplace as a source before installing its skills:
+
+```
+/plugin marketplace add <github_owner/repo>
+```
+
+!!! note
+    The official Anthropic marketplace (`claude-plugins-official`) is
+    pre-registered and requires no `add` step.
+
+### Install a skill
+
+Once a marketplace is registered, install skills by name using the format
+`skill-name@marketplace-name`:
+
+```
+/plugin install code-review@claude-plugins-official
+```
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+ ▐▛███▜▌   Claude Code v2.1.109
+▝▜█████▛▘  Sonnet 4.6 · Claude Team
+  ▘▘ ▝▝    ~/CODE/project
+
+❯ /plugin install code-review@claude-plugins-official
+  ⎿  ✓ Installed code-review. Run /reload-plugins to apply.
+```
+</div>
+
+After installing, activate the skill in the current session without
+restarting:
+
+```
+/reload-plugins
+```
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+ ▐▛███▜▌   Claude Code v2.1.109
+▝▜█████▛▘  Sonnet 4.6 · Claude Team
+  ▘▘ ▝▝    ~/CODE/project
+
+❯ /plugin install code-review@claude-plugins-official
+  ⎿  ✓ Installed code-review. Run /reload-plugins to apply.
+
+❯ /reload-plugins
+  ⎿  Reloaded: 1 plugins · 0 skill · 5 agents · 0 hooks · 0 plugin MCP servers · 0 plugin LSP servers
+```
+</div>
+
+Run `/plugin` and navigate to the **Installed** tab to list all currently
+installed skills.
+
+```
+/plugin
+```
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+ ▐▛███▜▌   Claude Code v2.1.109
+▝▜█████▛▘  Sonnet 4.6 · Claude Team
+  ▘▘ ▝▝    ~/CODE/project
+
+❯ /plugin
+
+--------------------------------------------------------------------------------
+  Plugins  Discover  *Installed*  Marketplaces   Errors
+
+  ╭────────────────────────────────────────────────────────────────────────────╮
+  │ ⌕ Search…                                                                  │
+  ╰────────────────────────────────────────────────────────────────────────────╯
+
+    Local
+  ❯ code-review Plugin · claude-plugins-official · ✔ enabled
+
+   type to search · Space to toggle · Enter to details · Esc to back
+```
+</div>
+
+### Explore the official skills library
+
+The `/plugin` command opens an interactive manager with four tabs: **Discover**,
+**Installed**, **Marketplaces**, and **Errors**. Use the **Discover** tab to
+browse skills across registered marketplaces.
+
+The official Anthropic marketplace includes skills in four categories:
+
+- **Code intelligence** — language server integrations for Python, Rust,
+  TypeScript, Go, and more
+- **External integrations** — GitHub, GitLab, Jira, Figma, Slack, Vercel, and
+  other services
+- **Development workflows** — commit tools, PR review, and plugin development
+- **Output styles** — response customization
+
+For the full catalogue, see the [Claude Code plugin
+documentation](https://code.claude.com/docs/en/discover-plugins).
+
+### Manage installed skills
+
+#### Update a marketplace
+
+Pull the latest skill definitions from a registered marketplace:
+
+```
+/plugin marketplace update claude-plugins-official
+```
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+ ▐▛███▜▌   Claude Code v2.1.109
+▝▜█████▛▘  Sonnet 4.6 · Claude Team
+  ▘▘ ▝▝    ~/CODE/project
+
+❯ /plugin marketplace update claude-plugins-official
+  ⎿  ✔ Updated 1 marketplace
+```
+</div>
+
+#### Remove a skill
+
+Uninstall a skill from the current user scope:
+
+```
+/plugin uninstall code-review
+```
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+ ▐▛███▜▌   Claude Code v2.1.109
+▝▜█████▛▘  Sonnet 4.6 · Claude Team
+  ▘▘ ▝▝    ~/CODE/project
+
+❯ /plugin uninstall code-review
+  ⎿  ✓ Enabled code-review. Run /reload-plugins to apply.
+```
+</div>
+
+#### Remove a marketplace source
+
+Remove a marketplace and make its skills unavailable for future installs:
+
+```
+/plugin marketplace remove github_username/project
+```
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+ ▐▛███▜▌   Claude Code v2.1.109
+▝▜█████▛▘  Sonnet 4.6 · Claude Team
+  ▘▘ ▝▝    ~/CODE/project
+
+❯ /plugin marketplace remove mila-skills
+  ⎿  ✔ Removed 1 marketplace
+```
+</div>
+
+---
+
+## Key concepts
+
+**Claude Code**
+:   Anthropic's official CLI and IDE extension for Claude. Provides an AI coding
+    assistant in the terminal or IDE, extendable with skills.
+
+**Skill**
+:   A self-contained workflow that extends Claude Code with domain-specific
+    behavior. Skills are invoked as slash commands (e.g.
+    `/mila-connect-cluster`) in a Claude Code session.
+
+**Marketplace**
+:   A GitHub repository containing one or more skill definitions. Adding a
+    marketplace as a source makes its skills available to install.
+
+## Next step
+
+<div class="grid cards" markdown>
+
+-   [:material-toy-brick:{ .lg .middle } __Install Mila Skills for Claude Code__](mila_skills.md)
+    { .card }
+
+    ---
+    Add the Mila skills marketplace and install cluster-focused skills for
+    account setup, SSH connections, and job submission.
+
+&nbsp;
+
+</div>

--- a/docs/ai/index.md
+++ b/docs/ai/index.md
@@ -1,3 +1,29 @@
-!!! wip "Work in progress"
+---
+title: AI Agents
+description: >-
+  Guides for AI coding tools available to Mila researchers, including Claude
+  Code and Mila-specific skills.
+---
 
-    We are currently working on this section.
+# AI agents
+
+AI coding tools help researchers work more effectively on the Mila cluster. Find
+guides for setting up Claude Code and installing Mila-specific skills for SSH
+connections, account management, and job submission.
+
+<div class="grid cards" markdown>
+
+-   [:material-robot:{ .lg .middle } __Set Up Claude Code__](claude_code.md)
+    { .card }
+
+    ---
+    Install Claude Code and extend Claude Code with skills from a marketplace.
+
+-   [:material-toy-brick:{ .lg .middle } __Install Mila Skills for Claude Code__](mila_skills.md)
+    { .card }
+
+    ---
+    Add the Mila skills marketplace and install cluster-focused skills for
+    account setup, SSH connections, and job submission.
+
+</div>

--- a/docs/ai/mila_skills.md
+++ b/docs/ai/mila_skills.md
@@ -1,0 +1,162 @@
+---
+title: Install Mila Skills for Claude Code
+description: >-
+  Add the Mila skills marketplace to Claude Code and install cluster-focused
+  skills for account setup, SSH connections, and job submission.
+---
+
+# Install Mila Skills for Claude Code
+
+The [mila-iqai/skills](https://github.com/mila-iqia/skills) marketplace is a
+curated collection of Claude Code skills for Mila cluster workflows. Once
+installed, each skill becomes available as a slash command that guides
+researchers through common tasks — from setting up a Mila account to submitting
+batch jobs with sbatch. This guide covers adding the marketplace to Claude Code
+and installing the mila-* skills.
+
+## Before you begin
+
+<div class="grid cards" markdown>
+
+-   [:material-robot:{ .lg .middle } __Set Up Claude Code__](claude_code.md)
+    { .card }
+
+    ---
+    Install Claude Code and extend Claude Code with skills from a marketplace.
+
+&nbsp;
+
+</div>
+
+## What this guide covers
+
+* Add the [mila-iqai/skills](https://github.com/mila-iqia/skills) marketplace as
+  a source in Claude Code
+* Review the available Mila Skills
+* Install and invoke a Mila Skill
+
+---
+
+## Add the Mila Skills marketplace
+
+In a Claude Code session, run the following command to register the
+mila-iqai/skills repository as a marketplace source:
+
+```
+/plugin marketplace add mila-iqia/skills
+```
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+ ▐▛███▜▌   Claude Code v2.1.109
+▝▜█████▛▘  Sonnet 4.6 · Claude Team
+  ▘▘ ▝▝    ~/CODE/project
+
+❯ /plugin marketplace add mila-iqia/skills
+  ⎿  Successfully added marketplace: mila-skills
+```
+</div>
+
+Claude Code fetches the marketplace metadata and makes the available skills
+visible for installation.
+
+!!! note
+    Verify the command above against the [mila-iqai/skills
+    README](https://github.com/mila-iqia/skills) — the marketplace API may
+    evolve over time.
+
+## Available Mila Skills
+
+The marketplace provides the following skills for Mila cluster workflows:
+
+| Skill | Description |
+|---|---|
+| `/mila-account-setup` | Obtain a Mila account, enable cluster access, and configure multi-factor authentication. |
+| `/mila-local-setup` | Install WSL2, uv, and milatools on a local machine. |
+| `/mila-connect-cluster` | Connect to the cluster over SSH, enter a one-time password, and troubleshoot connectivity issues. |
+| `/mila-run-jobs` | Run interactive development sessions and submit batch jobs with sbatch. |
+
+## Install and invoke a skill
+
+Install all Mila Skills with:
+
+```
+/plugin install mila-tools@mila-skills
+```
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+ ▐▛███▜▌   Claude Code v2.1.109
+▝▜█████▛▘  Sonnet 4.6 · Claude Team
+  ▘▘ ▝▝    ~/CODE/project
+
+❯ /plugin install mila-tools@mila-skills
+  ⎿  ✓ Installed mila-tools. Run /reload-plugins to apply.
+```
+</div>
+
+After installing, activate the skills in the current session without
+restarting:
+
+```
+/reload-plugins
+```
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+ ▐▛███▜▌   Claude Code v2.1.109
+▝▜█████▛▘  Sonnet 4.6 · Claude Team
+  ▘▘ ▝▝    ~/CODE/project
+
+❯ /reload-plugins
+  ⎿  Reloaded: 1 plugin · 0 skills · 5 agents · 0 hooks · 0 plugin MCP servers · 0 plugin LSP servers
+```
+</div>
+
+Once installed, invoke any skill as a slash command in a Claude Code session to
+be guided through the selected workflow step by step or ask any related
+questions:
+
+```
+I can't seem to login to the 2FA thing, I use my username and the supplied password in the email but it won't let me logon. What could be the reason for this?
+```
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+ ▐▛███▜▌   Claude Code v2.1.109
+▝▜█████▛▘  Sonnet 4.6 · Claude Team
+  ▘▘ ▝▝    ~/CODE/project
+
+❯ I can't seem to login to the 2FA thing, I use my username and the supplied
+  password in the email but it won't let me logon. What could be the reason for
+  this?
+
+⏺ Skill(mila-tools:mila-account-setup)
+  ⎿  Successfully loaded skill
+
+⏺ Fetch(https://docs.mila.quebec/getting_started/)
+  ⎿  Received 115.7KB (200 OK)
+
+⏺ The most likely reason you can't log in is that you're using the wrong
+  credentials. The MFA portal at https://mfa.mila.quebec uses different
+  credentials from what you might expect:
+
+  - Username: Your cluster username (not your @mila.quebec email address)
+  - Password: The one-time registration token from the IT email with subject
+    "Votre accès temporaire registrationcode / Your temporary access
+    registrationcode" — not your Mila account password
+
+  A few common scenarios:
+
+  1. Wrong username — make sure you're using your cluster username, not your
+     email address.
+  2. Wrong password — the password field expects the registration token from
+     that specific IT email, not your regular password.
+  3. Token already used — if you previously logged in to the portal but left
+     without adding a TOTP token, the registration token is now expired. You'd
+     need to contact IT support at https://it-support.mila.quebec to get a new
+     one.
+
+  If you're still stuck after trying the above, reach out to IT support and ask
+  for a new registration token.
+
+  Sources:
+  - https://docs.mila.quebec/getting_started/
+```
+</div>

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -18,7 +18,7 @@ skills:
 This guide covers obtaining a Mila account, connecting to the cluster, and
 setting up the tools needed to run jobs. Follow the steps in order.
 
-## Before you begin { #obtain-your-mila-account #enable-your-cluster-access }
+## Before you begin { #obtain-your-mila-account #enable-your-cluster-access #install-wsl }
 
 ???+ success "Obtain your Mila account (`@mila.quebec`)"
 

--- a/docs/getting_started/my_first_job.md
+++ b/docs/getting_started/my_first_job.md
@@ -12,7 +12,7 @@ skills:
 
 This guide covers running a first job on the Mila cluster. Create a minimal
 PyTorch project that checks CUDA and GPU availability, and develop on the
-cluster using [VSCode](VSCode.md) on a compute node via the [`mila
+cluster using [VSCode](https://code.visualstudio.com/) on a compute node via the [`mila
 code`](https://github.com/mila-iqia/milatools) command from
 [milatools](https://github.com/mila-iqia/milatools).
 


### PR DESCRIPTION
## Summary
Adds two new documentation guides for AI tooling: one for installing and authenticating Claude Code, and one for adding the Mila skills marketplace and installing cluster-focused skills.

## Changes
- New `docs/ai/claude_code.md`: full guide covering CLI/IDE installation, authentication, and the `/plugin` skill marketplace workflow.
- New `docs/ai/mila_skills.md`: guide for registering `mila-iqai/skills` as a marketplace and installing/invoking `mila-tools` skills.
- Updated `docs/ai/index.md`: replaced the "Work in progress" placeholder with a landing page linking to both new guides.
- Updated `docs/README.md`: added both new pages to the table of contents under the AI agents section.
- Added `#install-wsl` anchor to `getting_started/index.md` so the Claude Code guide can deep-link to the WSL2 setup step.
- Fixed the VSCode link in `my_first_job.md` to point to the official VS Code website instead of the internal page.