### PR TITLE
Revert "Update CODEOWNERS to include additional owners (#392)"

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,2 @@
-# Main code owners : @lebrice @satyaog @obilaniu @soline-b
-*        @lebrice @satyaog @obilaniu @soline-b @ahmam @pbouchez @charlesouel @milaflq @Daria-Kr @larose-mila @marielpaq @nihmatof
+*        @lebrice @satyaog @obilaniu @soline-b
 # docs/examples/        @lebrice @satyaog @obilaniu


### PR DESCRIPTION
I couldn't find a setting to avoid notifying all codeowners on new PR. Reverting this until we find a better solution with Infra

This reverts commit 0fca4836f0997faa3f8b2a84eab71ed336f642b8.