### PR TITLE
Replace Biel.ai with DocSearch and add Mila Docs MCP guide

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,8 +23,6 @@ build:
     install:
       - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync
     pre_build:
-      # Uncomment this if you want to disable Biel search
-      # - rm -f overrides/partials/search.html
       - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv run
         --script docs/examples/preprocess.py
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -133,6 +133,7 @@ If you find any errors in the documentation, missing or unclear sections, or wou
 - [AI agents](ai/index.md)
     - [Set Up Claude Code](ai/claude_code.md)
     - [Install Mila Skills for Claude Code](ai/mila_skills.md)
+    - [Mila-Aware AI Assistance with MCP](ai/mcp.md)
 - [Technical reference](technical_reference/index.md)
     - [Cheatsheet](technical_reference/cheatsheet.md)
     - [Glossary](technical_reference/glossary.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -133,7 +133,7 @@ If you find any errors in the documentation, missing or unclear sections, or wou
 - [AI agents](ai/index.md)
     - [Set Up Claude Code](ai/claude_code.md)
     - [Install Mila Skills for Claude Code](ai/mila_skills.md)
-    - [Mila-Aware AI Assistance with MCP](ai/mcp.md)
+    - [Mila Docs MCP Server](ai/mcp.md)
 - [Technical reference](technical_reference/index.md)
     - [Cheatsheet](technical_reference/cheatsheet.md)
     - [Glossary](technical_reference/glossary.md)

--- a/docs/ai/claude_code.md
+++ b/docs/ai/claude_code.md
@@ -350,6 +350,11 @@ Remove a marketplace and make its skills unavailable for future installs:
     Add the Mila skills marketplace and install cluster-focused skills for
     account setup, SSH connections, and job submission.
 
-&nbsp;
+-   [:material-brain:{ .lg .middle } __Mila-Aware AI Assistance with MCP__](mcp.md)
+    { .card }
+
+    ---
+    Configure the Mila Docs MCP server so that AI assistants can draw on Mila
+    documentation automatically.
 
 </div>

--- a/docs/ai/claude_code.md
+++ b/docs/ai/claude_code.md
@@ -350,7 +350,7 @@ Remove a marketplace and make its skills unavailable for future installs:
     Add the Mila skills marketplace and install cluster-focused skills for
     account setup, SSH connections, and job submission.
 
--   [:material-brain:{ .lg .middle } __Mila-Aware AI Assistance with MCP__](mcp.md)
+-   [:material-brain:{ .lg .middle } __Mila Docs MCP Server__](mcp.md)
     { .card }
 
     ---

--- a/docs/ai/index.md
+++ b/docs/ai/index.md
@@ -26,4 +26,11 @@ connections, account management, and job submission.
     Add the Mila skills marketplace and install cluster-focused skills for
     account setup, SSH connections, and job submission.
 
+-   [:material-brain:{ .lg .middle } __Mila-Aware AI Assistance with MCP__](mcp.md)
+    { .card }
+
+    ---
+    Configure the Mila Docs MCP server so that AI assistants can draw on Mila
+    documentation automatically.
+
 </div>

--- a/docs/ai/index.md
+++ b/docs/ai/index.md
@@ -26,7 +26,7 @@ connections, account management, and job submission.
     Add the Mila skills marketplace and install cluster-focused skills for
     account setup, SSH connections, and job submission.
 
--   [:material-brain:{ .lg .middle } __Mila-Aware AI Assistance with MCP__](mcp.md)
+-   [:material-brain:{ .lg .middle } __Mila Docs MCP Server__](mcp.md)
     { .card }
 
     ---

--- a/docs/ai/mcp.md
+++ b/docs/ai/mcp.md
@@ -1,0 +1,205 @@
+---
+title: Mila-Aware AI Assistance with MCP
+description: >-
+  Configure the Mila Docs MCP server so that AI assistants can draw on Mila
+  documentation automatically.
+---
+
+# Mila-Aware AI Assistance with MCP
+
+The Model Context Protocol (MCP) is an open standard that lets AI assistants
+connect to external knowledge sources as callable tools. Configuring the Mila
+Docs MCP server gives Claude Code or Cursor access to the full Mila
+documentation index — so when a question touches cluster commands, Slurm syntax,
+storage policies, or account setup, the assistant can pull in accurate,
+up-to-date Mila guidance automatically, without requiring a separate search.
+
+## Before you begin
+
+<div class="grid cards" markdown>
+
+-   [:material-robot:{ .lg .middle } __Set Up Claude Code__](claude_code.md)
+    { .card }
+
+    ---
+    Install Claude Code and extend it with skills from a marketplace.
+
+&nbsp;
+
+</div>
+
+## What this guide covers
+
+* Understand what MCP is and how the Mila Docs MCP server works
+* Configure the Mila Docs MCP server
+* See an example of the assistant using Mila context to answer a question
+
+---
+
+## What is MCP?
+
+MCP (Model Context Protocol) is an open standard that defines how AI tools
+communicate with external services. An MCP **server** exposes one or more tools
+— actions the AI can invoke, such as searching a database or fetching a web
+page. The AI tool (Claude Code, Cursor) acts as the MCP **client**: it discovers
+available tools on startup, then calls them automatically when a query requires
+external data.
+
+```mermaid
+sequenceDiagram
+    participant A as AI assistant
+    participant S as MCP server (Algolia)
+    participant D as Mila docs index
+
+    A->>S: algolia_search_mila_docs("sbatch options")
+    S->>D: Search query
+    D-->>S: Matching documentation
+    S-->>A: Search results with source links
+```
+
+## The Mila Docs MCP server
+
+The Mila documentation site is indexed by
+[DocSearch](https://docsearch.algolia.com/) made by Algolia and exposes a public
+MCP server at the following endpoint:
+
+```
+https://558773LESW.algolia.net/mcp/1/3_N8rKyLQhaxUEpt0FMx6A/mcp
+```
+
+The server exposes a search tool that accepts natural-language queries and
+returns matching sections of the Mila documentation. The Search API key is
+embedded in the URL — no additional authentication is required.
+
+## Configure in Claude Code
+
+=== "CLI (recommended)"
+
+    Run the following command to register the Mila Docs MCP server:
+
+    ```bash
+    claude mcp add --transport http mila-docs \
+        https://558773LESW.algolia.net/mcp/1/3_N8rKyLQhaxUEpt0FMx6A/mcp
+    ```
+    <div class="result" style="border:None; padding:0" markdown>
+    ``` linenums="0"
+    Added HTTP MCP server mila-docs with URL: https://558773LESW.algolia.net/mcp/1/3_N8rKyLQhaxUEpt0FMx6A/mcp to local config
+    File modified: /Users/username/.claude.json [project: /Users/username/CODE/mila-docs]
+    ```
+    </div>
+
+    The server is registered globally and becomes available in all Claude Code
+    sessions.
+
+    !!! tip
+        Add `--scope project` to limit the server to the current
+        project only.
+
+=== "Config file"
+
+    Add the server entry to `~/.claude.json` (global) or `.claude/settings.json`
+    (project-level):
+
+    ```json
+    {
+      "mcpServers": {
+        "mila-docs": {
+          "type": "http",
+          "url": "https://558773LESW.algolia.net/mcp/1/3_N8rKyLQhaxUEpt0FMx6A/mcp"
+        }
+      }
+    }
+    ```
+
+    Restart Claude Code after saving the file.
+
+## Configure in Cursor
+
+Cursor reads MCP configuration from a JSON file. Create or edit the file at one
+of the following paths:
+
+| Scope | File |
+|-------|------|
+| Global (all projects) | `~/.cursor/mcp.json` |
+| Project only | `.cursor/mcp.json` (project root) |
+
+Add the following entry:
+
+```json
+{
+  "mcpServers": {
+    "mila-docs": {
+      "url": "https://558773LESW.algolia.net/mcp/1/3_N8rKyLQhaxUEpt0FMx6A/mcp"
+    }
+  }
+}
+```
+
+After saving, open **Cursor Settings → MCP** and confirm that `mila-docs` shows
+a green status indicator.
+
+## Ask the assistant about Mila
+
+Once the MCP server is configured, the AI assistant can answer questions about
+Mila systems accurately — drawing on the documentation automatically as part of
+the normal conversation flow.
+
+**Example — in a Claude Code session:**
+
+```
+How do I cancel a running Slurm job on the Mila cluster?
+```
+<div class="result" style="border:None; padding:0" markdown>
+``` linenums="0"
+ ▐▛███▜▌   Claude Code v2.1.109
+▝▜█████▛▘  Sonnet 4.6 · Claude Team
+  ▘▘ ▝▝    ~/CODE/project
+
+⏺ Use scancel with your job ID:
+
+  # Cancel a specific job
+  scancel <JOBID>
+
+  # Cancel all your jobs (running and pending)
+  scancel -u YOUR_USERNAME
+
+  # Cancel only your pending jobs
+  scancel -t PD
+
+  To find your job ID first, run squeue --me. More details in the https://docs.mila.quebec/help/faq/#how-do-i-cancel-a-job.
+```
+</div>
+
+!!! tip
+    Phrase queries naturally — no special syntax is required. The assistant
+    selects the search tool and constructs the query automatically.
+
+---
+
+## Key concepts
+
+**MCP (Model Context Protocol)**
+:   Open standard that defines how AI tools communicate with external services
+    using a client/server model.
+
+**MCP server**
+:   A service that exposes tools an AI assistant can invoke. The Mila Docs MCP
+    server exposes Algolia search over the Mila documentation index.
+
+**MCP client**
+:   The AI tool (Claude Code, Cursor) that connects to MCP servers, discovers
+    their tools, and calls them automatically.
+
+## Next steps
+
+<div class="grid cards" markdown>
+
+-   [:material-toy-brick:{ .lg .middle } __Install Mila Skills for Claude Code__](mila_skills.md)
+    { .card }
+
+    ---
+    Add the Mila skills marketplace and install cluster-focused skills.
+
+&nbsp;
+
+</div>

--- a/docs/ai/mcp.md
+++ b/docs/ai/mcp.md
@@ -1,11 +1,11 @@
 ---
-title: Mila-Aware AI Assistance with MCP
+title: Mila Docs MCP Server
 description: >-
   Configure the Mila Docs MCP server so that AI assistants can draw on Mila
   documentation automatically.
 ---
 
-# Mila-Aware AI Assistance with MCP
+# Mila Docs MCP Server
 
 The Model Context Protocol (MCP) is an open standard that lets AI assistants
 connect to external knowledge sources as callable tools. Configuring the Mila

--- a/docs/ai/mila_skills.md
+++ b/docs/ai/mila_skills.md
@@ -160,3 +160,18 @@ I can't seem to login to the 2FA thing, I use my username and the supplied passw
   - https://docs.mila.quebec/getting_started/
 ```
 </div>
+
+## Next step
+
+<div class="grid cards" markdown>
+
+-   [:material-brain:{ .lg .middle } __Mila-Aware AI Assistance with MCP__](mcp.md)
+    { .card }
+
+    ---
+    Configure the Mila Docs MCP server so that AI assistants can draw on Mila
+    documentation automatically.
+
+&nbsp;
+
+</div>

--- a/docs/ai/mila_skills.md
+++ b/docs/ai/mila_skills.md
@@ -165,7 +165,7 @@ I can't seem to login to the 2FA thing, I use my username and the supplied passw
 
 <div class="grid cards" markdown>
 
--   [:material-brain:{ .lg .middle } __Mila-Aware AI Assistance with MCP__](mcp.md)
+-   [:material-brain:{ .lg .middle } __Mila Docs MCP Server__](mcp.md)
     { .card }
 
     ---

--- a/docs/generated_from_config/.gitignore
+++ b/docs/generated_from_config/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -31,3 +31,18 @@ a.full-card:hover {
 .skill-identifiers {
   display: none;
 }
+
+/* DocSearch: fix small text (higher specificity needed — DocSearch CSS loads after extra.css) */
+.DocSearch-Modal .DocSearch-Input,
+.DocSearch-Modal .DocSearch-Hits,
+.DocSearch-Modal .DocSearch-AskAi-Section,
+.DocSearch-Modal .DocSearch-AskAiScreen-Response {
+    font-size: 0.8rem;
+}
+
+.DocSearch-Modal .DocSearch-Label,
+.DocSearch-Modal .DocSearch-Clear,
+.DocSearch-Modal .DocSearch-AskAiScreen-Disclaimer,
+.DocSearch-Modal .DocSearch-AskAiScreen-RelatedSources-Item-Link {
+    font-size: 0.6rem;
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -32,17 +32,26 @@ a.full-card:hover {
   display: none;
 }
 
-/* DocSearch: fix small text (higher specificity needed — DocSearch CSS loads after extra.css) */
-.DocSearch-Modal .DocSearch-Input,
-.DocSearch-Modal .DocSearch-Hits,
-.DocSearch-Modal .DocSearch-AskAi-Section,
-.DocSearch-Modal .DocSearch-AskAiScreen-Response {
+/*
+* DocSearch: override the inherited font-size so internal em values scale from
+* 0.8rem rather than the theme's default.
+ */
+.DocSearch-Modal,
+.DocSearch-Sidepanel,
+#docsearch .DocSearch-Button-Placeholder {
     font-size: 0.8rem;
 }
 
-.DocSearch-Modal .DocSearch-Label,
-.DocSearch-Modal .DocSearch-Clear,
-.DocSearch-Modal .DocSearch-AskAiScreen-Disclaimer,
-.DocSearch-Modal .DocSearch-AskAiScreen-RelatedSources-Item-Link {
-    font-size: 0.6rem;
+/*
+ * DocSearch: shrink floating Ask AI button to ~2/3 of its default size
+ */
+.DocSearch-SidepanelButton.floating {
+    transform: scale(0.6);
+    transform-origin: bottom right;
+    --docsearch-sidepanel-primary: var(--md-primary-fg-color);
+}
+
+.DocSearch-SidepanelButton.floating:focus,
+.DocSearch-SidepanelButton.floating:hover {
+    --docsearch-sidepanel-primary-dark: var(--md-primary-fg-color--dark);
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,9 +38,9 @@ theme:
     - navigation.instant
     - navigation.tabs
     - navigation.tabs.sticky
-    - search.suggest
     - search.highlight
     - search.share
+    - search.suggest
   palette:
     # Palette toggle for automatic mode
     - media: "(prefers-color-scheme)"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,7 @@
 site_name: Mila Technical Documentation
+# TODO: it might be possible to use something like
+# https://docs.mila.quebec/en/401/ as the site_url to avoid relying on relative
+# paths in the doc (../resource instead of /resource)
 site_url: https://docs.mila.quebec
 repo_name: mila-docs
 repo_url: https://github.com/mila-iqia/mila-docs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Mila Technical Documentation
 site_url: https://docs.mila.quebec
 repo_name: mila-docs
-repo_url: https://www.github.com/mila-iqia/mila-docs
+repo_url: https://github.com/mila-iqia/mila-docs
 docs_dir: docs
 edit_uri: edit/master/docs/
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,9 +33,9 @@ theme:
     ## Don't auto- expand until maybe after we reorganize the content a bit.
     ## Atm it's too many pages all at once, and doesn't match the sphinx structure.
     # - navigation.expand
-    - navigation.path
     - navigation.indexes
     - navigation.instant
+    - navigation.path
     - navigation.tabs
     - navigation.tabs.sticky
     - search.highlight

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -19,62 +19,55 @@ and we'll take a look at it!
 
 <!-- Biel.ai search boost -->
 <meta name="biel:boost_score" content="0.5">
+
+<!-- DocSearch verification -->
+<meta name="algolia-site-verification"  content="3EAD36F59F913078" />
+
+<!-- DocSearch styles -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@4" />
+
+<!-- DocSearch script -->
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@4"></script>
 {% endblock %}
 
 {% block content %}
 {{ super() }}
+{% endblock %}
 
-<biel-button project="jonj6uji9x" header-title="Documentation AI" button-position="bottom-right"
-    modal-position="bottom-right" button-style="dark">
-    Ask AI
-</biel-button>
-{% endblock %} {% block scripts %} {{ super() }}
-<!--
-  Biel replaces Material’s built-in search UI, but Material’s keyboard layer
-  still decides "search mode" from the hidden #__search checkbox (see
-  mkdocs-material watchKeyboard + bundle global shortcuts). While that box stays
-  unchecked, keys like n/p still run prev/next navigation even when a Biel modal
-  is open.
-
-  Material reads #__search.checked synchronously on every keydown event, so we
-  don’t need continuous MutationObserver sync. A capture-phase listener fires
-  before Material’s bubble-phase handler on window, giving us time to sync the
-  checkbox lazily — only when a key is actually pressed.
-
-  We set .checked and dispatch "change" instead of .click() so we don’t move
-  focus to the hidden input (which would blur Biel and close its modals).
--->
+{% block scripts %}
+{{ super() }}
+{% raw %}
 <script>
-    (function () {
-        // Attribute names used by each Biel element to signal an open modal.
-        var MATERIAL_SEARCH_ID = "__search";
-        var BIEL_SEARCH_ATTR = "show-search-modal";
-        var BIEL_BOT_ATTR = "show-modal";
-
-        // Returns true if any Biel modal is currently open.
-        function anyBielOverlayOpen() {
-            var search = document.querySelector("biel-search");
-            var bot = document.querySelector("biel-bot");
-            return (
-                Boolean(search && search.hasAttribute(BIEL_SEARCH_ATTR)) ||
-                Boolean(bot && bot.hasAttribute(BIEL_BOT_ATTR))
-            );
+    let currentQuery = '';
+    document.addEventListener('input', function(e) {
+        if (e.target.classList.contains('DocSearch-Input')) {
+            currentQuery = e.target.value;
         }
-
-        // Sync the checkbox in the capture phase so Material reads the correct
-        // mode when its bubble-phase handler fires on window.
-        document.addEventListener(
-            "keydown",
-            function () {
-                var toggle = document.getElementById(MATERIAL_SEARCH_ID);
-                if (!toggle || toggle.type !== "checkbox") return;
-                var isOpen = anyBielOverlayOpen();
-                if (toggle.checked === isOpen) return;
-                toggle.checked = isOpen;
-                toggle.dispatchEvent(new Event("change", { bubbles: true }));
+    }, true);
+    docsearch({
+        container: "#docsearch",
+        appId: "558773LESW",
+        apiKey: "c025866a1987f29d1b086637d06853a6",
+        indices: [
+            {
+                name: "MILA Docs",
             },
-            true,
-        );
-    })();
+        ],
+        placeholder: "Search the docs",
+        hitComponent({ hit, children }, { html }) {
+            const separator = hit.url.includes('?') ? '&' : '?';
+            const url = currentQuery
+                ? `${hit.url}${separator}h=${encodeURIComponent(currentQuery)}`
+                : hit.url;
+            return html`<a href="${url}">${children}</a>;`;
+        },
+        // Agent Studio configuration
+        askAi: {
+            assistantId: "d9b031b9-047c-4b63-a794-010d037dce19",
+            agentStudio: true,
+            suggestedQuestions: true,
+        },
+    });
 </script>
+{% endraw %}
 {% endblock %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -11,23 +11,17 @@ and we'll take a look at it!
 {% endblock %}
 
 {% block extrahead %}
-<!-- Biel.ai styles -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/biel-search/dist/biel-search/biel-search.css">
-
-<!-- Biel.ai script -->
-<script type="module" src="https://cdn.jsdelivr.net/npm/biel-search/dist/biel-search/biel-search.esm.js"></script>
-
-<!-- Biel.ai search boost -->
-<meta name="biel:boost_score" content="0.5">
-
 <!-- DocSearch verification -->
 <meta name="algolia-site-verification"  content="3EAD36F59F913078" />
 
 <!-- DocSearch styles -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@4" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css/dist/style.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css/dist/sidepanel.css" />
 
-<!-- DocSearch script -->
+<!-- DocSearch scripts -->
 <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@4"></script>
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/sidepanel-js"></script>
 {% endblock %}
 
 {% block content %}
@@ -37,13 +31,25 @@ and we'll take a look at it!
 {% block scripts %}
 {{ super() }}
 {% raw %}
+<div id="docsearch-sidepanel"></div>
 <script>
-    let currentQuery = '';
-    document.addEventListener('input', function(e) {
-        if (e.target.classList.contains('DocSearch-Input')) {
-            currentQuery = e.target.value;
-        }
-    }, true);
+    let currentQuery = "";
+    document.addEventListener(
+        "input",
+        function (e) {
+            if (e.target.classList.contains("DocSearch-Input")) {
+                currentQuery = e.target.value;
+            }
+        },
+        true,
+    );
+
+    var palette = __md_get("__palette");
+    theme = "light";
+    if (palette && typeof palette.color === "object") {
+        var theme = palette.color.scheme === "slate" ? "dark" : "light";
+    }
+
     docsearch({
         container: "#docsearch",
         appId: "558773LESW",
@@ -53,9 +59,13 @@ and we'll take a look at it!
                 name: "MILA Docs",
             },
         ],
+        insights: true,
         placeholder: "Search the docs",
+        translations: {
+            button: { buttonText: "Search the docs" },
+        },
         hitComponent({ hit, children }, { html }) {
-            const separator = hit.url.includes('?') ? '&' : '?';
+            const separator = hit.url.includes("?") ? "&" : "?";
             const url = currentQuery
                 ? `${hit.url}${separator}h=${encodeURIComponent(currentQuery)}`
                 : hit.url;
@@ -65,8 +75,37 @@ and we'll take a look at it!
         askAi: {
             assistantId: "d9b031b9-047c-4b63-a794-010d037dce19",
             agentStudio: true,
-            suggestedQuestions: true,
+            // suggestedQuestions: true,
         },
+        theme: theme,
+    });
+
+    docsearchSidepanel({
+        container: "#docsearch-sidepanel",
+        appId: "558773LESW",
+        apiKey: "c025866a1987f29d1b086637d06853a6",
+        indices: [
+            {
+                name: "MILA Docs",
+            },
+        ],
+        assistantId: "d9b031b9-047c-4b63-a794-010d037dce19",
+        agentStudio: true,
+        // suggestedQuestions: true,
+        translations: {
+            header: {
+                title: "Ask the docs",
+            },
+            promptForm: {
+                promptPlaceholderText:
+                    "e.g. How do I connect to the Mila cluster?",
+            },
+        },
+        variant: "floating",
+        side: "right",
+        width: "580px",
+        expandedWidth: "640",
+        theme: theme,
     });
 </script>
 {% endraw %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -12,7 +12,7 @@ and we'll take a look at it!
 
 {% block extrahead %}
 <!-- DocSearch verification -->
-<meta name="algolia-site-verification"  content="3EAD36F59F913078" />
+<meta name="algolia-site-verification" content="3EAD36F59F913078" />
 
 <!-- DocSearch styles -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@4" />
@@ -62,13 +62,15 @@ and we'll take a look at it!
         insights: true,
         placeholder: "Search the docs",
         translations: {
-            button: { buttonText: "Search the docs" },
+            button: {buttonText: "Search the docs"},
         },
-        hitComponent({ hit, children }, { html }) {
-            const separator = hit.url.includes("?") ? "&" : "?";
-            const url = currentQuery
-                ? `${hit.url}${separator}h=${encodeURIComponent(currentQuery)}`
-                : hit.url;
+        hitComponent({hit, children}, {html}) {
+            const [base, hash] = hit.url.split("#");
+            const separator = base.includes("?") ? "&" : "?";
+            const urlWithQuery = currentQuery
+                ? `${base}${separator}h=${encodeURIComponent(currentQuery)}`
+                : base;
+            const url = hash ? `${urlWithQuery}#${hash}` : urlWithQuery;
             return html`<a href="${url}">${children}</a>;`;
         },
         // Agent Studio configuration

--- a/overrides/partials/footer.html
+++ b/overrides/partials/footer.html
@@ -26,80 +26,79 @@
 <!-- Footer -->
 <footer class="md-footer">
 
-    <!-- Link to previous and/or next page -->
-    {% if "navigation.footer" in features %}
-      {% if page.previous_page or page.next_page %}
-        {% if page.meta and page.meta.hide %}
-          {% set hidden = "hidden" if "footer" in page.meta.hide %}
-        {% endif %}
-        <nav
-          class="md-footer__inner md-grid"
-          aria-label="{{ lang.t('footer') }}"
-          {{ hidden }}
-        >
-  
-          <!-- Link to previous page -->
-          {% if page.previous_page %}
-            {% set direction = lang.t("footer.previous") %}
-            <a
-              href="{{ page.previous_page.url | url }}"
-              class="md-footer__link md-footer__link--prev"
-              aria-label="{{ direction }}: {{ page.previous_page.title | e }}"
-            >
-              <div class="md-footer__button md-icon">
-                {% set icon = config.theme.icon.previous or "material/arrow-left" %}
-                {% include ".icons/" ~ icon ~ ".svg" %}
-              </div>
-              <div class="md-footer__title">
-                <span class="md-footer__direction">
-                  {{ direction }}
-                </span>
-                <div class="md-ellipsis">
-                  {{ page.previous_page.title }}
-                </div>
-              </div>
-            </a>
-          {% endif %}
-  
-          <!-- Link to next page -->
-          {% if page.next_page %}
-            {% set direction = lang.t("footer.next") %}
-            <a
-              href="{{ page.next_page.url | url }}"
-              class="md-footer__link md-footer__link--next"
-              aria-label="{{ direction }}: {{ page.next_page.title | e }}"
-            >
-              <div class="md-footer__title">
-                <span class="md-footer__direction">
-                  {{ direction }}
-                </span>
-                <div class="md-ellipsis">
-                  {{ page.next_page.title }}
-                </div>
-              </div>
-              <div class="md-footer__button md-icon">
-                {% set icon = config.theme.icon.next or "material/arrow-right" %}
-                {% include ".icons/" ~ icon ~ ".svg" %}
-              </div>
-            </a>
-          {% endif %}
-        </nav>
+  <!-- Link to previous and/or next page -->
+  {% if "navigation.footer" in features %}
+    {% if page.previous_page or page.next_page %}
+      {% if page.meta and page.meta.hide %}
+        {% set hidden = "hidden" if "footer" in page.meta.hide %}
       {% endif %}
-    {% endif %}
-  
-    <!-- Further information -->
-    <div class="md-footer-meta md-typeset">
-      <div class="md-footer-meta__inner md-grid">
-        <!-- Mila footer -->
-        {% include "mila_footer.html" %}
+      <nav
+        class="md-footer__inner md-grid"
+        aria-label="{{ lang.t('footer') }}"
+        {{ hidden }}
+      >
 
-        <!-- Copyright -->
-        {% include "partials/copyright.html" %}
-  
-        <!-- Social links -->
-        {% if config.extra.social %}
-          {% include "partials/social.html" %}
+        <!-- Link to previous page -->
+        {% if page.previous_page %}
+          {% set direction = lang.t("footer.previous") %}
+          <a
+            href="{{ page.previous_page.url | url }}"
+            class="md-footer__link md-footer__link--prev"
+            aria-label="{{ direction }}: {{ page.previous_page.title | e }}"
+          >
+            <div class="md-footer__button md-icon">
+              {% set icon = config.theme.icon.previous or "material/arrow-left" %}
+              {% include ".icons/" ~ icon ~ ".svg" %}
+            </div>
+            <div class="md-footer__title">
+              <span class="md-footer__direction">
+                {{ direction }}
+              </span>
+              <div class="md-ellipsis">
+                {{ page.previous_page.title }}
+              </div>
+            </div>
+          </a>
         {% endif %}
-      </div>
+
+        <!-- Link to next page -->
+        {% if page.next_page %}
+          {% set direction = lang.t("footer.next") %}
+          <a
+            href="{{ page.next_page.url | url }}"
+            class="md-footer__link md-footer__link--next"
+            aria-label="{{ direction }}: {{ page.next_page.title | e }}"
+          >
+            <div class="md-footer__title">
+              <span class="md-footer__direction">
+                {{ direction }}
+              </span>
+              <div class="md-ellipsis">
+                {{ page.next_page.title }}
+              </div>
+            </div>
+            <div class="md-footer__button md-icon">
+              {% set icon = config.theme.icon.next or "material/arrow-right" %}
+              {% include ".icons/" ~ icon ~ ".svg" %}
+            </div>
+          </a>
+        {% endif %}
+      </nav>
+    {% endif %}
+  {% endif %}
+
+  <!-- Further information -->
+  <div class="md-footer-meta md-typeset">
+    <div class="md-footer-meta__inner md-grid">
+      <!-- Mila footer -->
+      {% include "mila_footer.html" %}
+
+      {% include "partials/copyright.html" %}
+
+      <!-- Social links -->
+      {% if config.extra.social %}
+        {% include "partials/social.html" %}
+      {% endif %}
     </div>
-  </footer>
+  </div>
+</footer>

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -1,5 +1,6 @@
 <!-- From https://github.com/squidfunk/mkdocs-material/blob/master/src/templates/partials/header.html,
  with some modifications -->
+
 <!--
   Copyright (c) 2016-2025 Martin Donath <martin.donath@squidfunk.com>
 

--- a/overrides/partials/search.html
+++ b/overrides/partials/search.html
@@ -1,1 +1,112 @@
-<div id="docsearch"></div>
+<!-- From https://github.com/squidfunk/mkdocs-material/blob/master/src/templates/partials/search.html,
+ with some modifications -->
+
+<!--
+  Copyright (c) 2016-2025 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Search interface -->
+<div class="md-search" data-md-component="search" role="dialog">
+  <label class="md-search__overlay" for="__search"></label>
+  <div id="docsearch" class="md-search__inner" role="search">
+    <form class="md-search__form" name="search">
+
+      <!-- Search input -->
+      <input
+        type="text"
+        class="md-search__input"
+        name="query"
+        aria-label="{{ lang.t('search.placeholder') }}"
+        placeholder="{{ lang.t('search.placeholder') }}"
+        autocapitalize="off"
+        autocorrect="off"
+        autocomplete="off"
+        spellcheck="false"
+        data-md-component="search-query"
+        required
+      />
+
+      <!-- Button to open search -->
+      <label class="md-search__icon md-icon" for="__search">
+        {% set icon = config.theme.icon.search or "material/magnify" %}
+        {% include ".icons/" ~ icon ~ ".svg" %}
+        {% set icon = config.theme.icon.previous or "material/arrow-left" %}
+        {% include ".icons/" ~ icon ~ ".svg" %}
+      </label>
+
+      <!-- Search options -->
+      <nav
+        class="md-search__options"
+        aria-label="{{ lang.t('search') }}"
+      >
+
+        <!-- Button to share search -->
+        {% if "search.share" in features %}
+          <a
+            href="javascript:void(0)"
+            class="md-search__icon md-icon"
+            title="{{ lang.t('search.share') }}"
+            aria-label="{{ lang.t('search.share') }}"
+            data-clipboard
+            data-clipboard-text=""
+            data-md-component="search-share"
+            tabindex="-1"
+          >
+            {% set icon = config.theme.icon.share or "material/share-variant" %}
+            {% include ".icons/" ~ icon ~ ".svg" %}
+          </a>
+        {% endif %}
+
+        <!-- Button to reset search -->
+        <button
+          type="reset"
+          class="md-search__icon md-icon"
+          title="{{ lang.t('search.reset') }}"
+          aria-label="{{ lang.t('search.reset') }}"
+          tabindex="-1"
+        >
+          {% set icon = config.theme.icon.close or "material/close" %}
+          {% include ".icons/" ~ icon ~ ".svg" %}
+        </button>
+      </nav>
+
+      <!-- Search suggestions -->
+      {% if "search.suggest" in features %}
+        <div
+          class="md-search__suggest"
+          data-md-component="search-suggest"
+        ></div>
+      {% endif %}
+    </form>
+    <div class="md-search__output">
+      <div class="md-search__scrollwrap" tabindex="0" data-md-scrollfix>
+
+        <!-- Search results -->
+        <div class="md-search-result" data-md-component="search-result">
+          <div class="md-search-result__meta">
+            {{ lang.t("search.result.initializer") }}
+          </div>
+          <ol class="md-search-result__list" role="presentation"></ol>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/overrides/partials/search.html
+++ b/overrides/partials/search.html
@@ -1,13 +1,1 @@
-<!-- Biel.ai search button (in header bar) -->
-
-<biel-search-button
-    project="jonj6uji9x"
-    header-title="Biel.ai Search"
-    button-position="bottom-right"
-    modal-position="sidebar-right"
-    button-style="rounded"
-    hide-ask-ai-button="true"
-    search-placeholder="Search the docs..."
->
-    Search the docs...
-</biel-search-button>
+<div id="docsearch"></div>


### PR DESCRIPTION
## Summary
Replaces the Biel.ai search widget with Algolia DocSearch (including an Ask AI sidepanel), and adds a new documentation page explaining how to configure the Mila Docs MCP server in Claude Code and Cursor.

## Changes
- `overrides/main.html`, `overrides/partials/search.html`: Remove Biel.ai components and keyboard-sync workaround; add DocSearch and DocSearch Sidepanel initialization with Algolia Agent Studio config.
- `docs/stylesheets/extra.css`: Add DocSearch font-size overrides and floating Ask AI button scale fix.
- `docs/ai/mcp.md`: New guide — explains MCP, the Mila Docs MCP server endpoint, and step-by-step configuration for Claude Code (CLI and config file) and Cursor.
- `docs/ai/index.md`, `docs/ai/claude_code.md`, `docs/ai/mila_skills.md`, `docs/README.md`: Add navigation cards linking to the new MCP guide.
- `mkdocs.yml`: Fix repo URL (`www.github.com` → `github.com`); add TODO comment about `site_url`.
- `.readthedocs.yaml`: Remove stale Biel.ai comment.
- `docs/generated_from_config/.gitignore`: Add gitignore to track the directory without its generated contents.

## Notes
- The Algolia Search API key is public (embedded in the MCP endpoint URL) — no secrets added.
- The DocSearch sidepanel floating button is scaled to 60% via CSS to reduce visual intrusiveness.
