### PR TITLE
Pin mkdocs below 2.0.0 to prevent breaking changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "mkdocs>=1.6.1",
+    "mkdocs>=1.6.1,<2.0.0",
     "mkdocs-material>=9.7.1",
     "mkdocs-include-markdown-plugin>=7.2.1",
     "mkdocs-literate-nav>=0.6.2",

--- a/uv.lock
+++ b/uv.lock
@@ -787,7 +787,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mkdocs", specifier = ">=1.6.1" },
+    { name = "mkdocs", specifier = ">=1.6.1,<2.0.0" },
     { name = "mkdocs-include-markdown-plugin", specifier = ">=7.2.1" },
     { name = "mkdocs-literate-nav", specifier = ">=0.6.2" },
     { name = "mkdocs-material", specifier = ">=9.7.1" },


### PR DESCRIPTION
Mkdocs>=2.0.0 will not support Material for MkDocs

https://github.com/orgs/ProperDocs/discussions/33

relates to #393