### PR TITLE
Standardize text and sections of Minimal Examples

### DIFF
--- a/docs/examples/advanced/imagenet/index.md
+++ b/docs/examples/advanced/imagenet/index.md
@@ -1,7 +1,9 @@
 # Multi-Node / Multi-GPU ImageNet Training
 
 
-Prerequisites:
+**Prerequisites**
+
+Make sure to read the following sections of the documentation before using this example:
 
 * [PyTorch Setup](../../frameworks/pytorch_setup/index.md)
 * [Single GPU](../../distributed/single_gpu/index.md)
@@ -16,7 +18,7 @@ Other interesting resources:
 * [Multi-node PyTorch distributed training guide](https://lambdalabs.com/blog/multi-node-pytorch-distributed-training-guide)
 
 
-Click here to see [the source code for this example](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/advanced/imagenet)
+The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/advanced/imagenet)
 
 
 This is an advanced and quite lengthy example. We recommend viewing the files directly

--- a/docs/examples/advanced/imagenet/index.md
+++ b/docs/examples/advanced/imagenet/index.md
@@ -1,7 +1,6 @@
 # Multi-Node / Multi-GPU ImageNet Training
 
-
-**Prerequisites**
+## Prerequisites
 
 Make sure to read the following sections of the documentation before using this example:
 
@@ -17,6 +16,7 @@ Other interesting resources:
 * https://sebarnold.net/dist_blog/
 * [Multi-node PyTorch distributed training guide](https://lambdalabs.com/blog/multi-node-pytorch-distributed-training-guide)
 
+## Example
 
 The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/advanced/imagenet)
 

--- a/docs/examples/distributed/multi_gpu/index.md
+++ b/docs/examples/distributed/multi_gpu/index.md
@@ -1,7 +1,6 @@
 # Multi-GPU Job
 
-
-**Prerequisites**
+## Prerequisites
 
 Make sure to read the following sections of the documentation before using this example:
 
@@ -12,6 +11,8 @@ Other interesting resources:
 
 * [sebarnold.net dist blog](https://sebarnold.net/dist_blog/)
 * [Multi-node PyTorch distributed training guide (Lambda Labs)](https://lambdalabs.com/blog/multi-node-pytorch-distributed-training-guide)
+
+## Example
 
 The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/distributed/multi_gpu)
 

--- a/docs/examples/distributed/multi_gpu/index.md
+++ b/docs/examples/distributed/multi_gpu/index.md
@@ -1,7 +1,9 @@
 # Multi-GPU Job
 
 
-Prerequisites:
+**Prerequisites**
+
+Make sure to read the following sections of the documentation before using this example:
 
 * [PyTorch Setup](../../frameworks/pytorch_setup/index.md)
 * [Single-GPU Job](../single_gpu/index.md)
@@ -11,7 +13,7 @@ Other interesting resources:
 * [sebarnold.net dist blog](https://sebarnold.net/dist_blog/)
 * [Multi-node PyTorch distributed training guide (Lambda Labs)](https://lambdalabs.com/blog/multi-node-pytorch-distributed-training-guide)
 
-Click here to see [the code for this example](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/distributed/multi_gpu)
+The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/distributed/multi_gpu)
 
 **job.sh**
 

--- a/docs/examples/distributed/multi_node/index.md
+++ b/docs/examples/distributed/multi_node/index.md
@@ -15,7 +15,7 @@ Other interesting resources:
 
 ## Example
 
-The full source code for this example is available on [the mila-docs GitHubrepository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/distributed/multi_node)
+The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/distributed/multi_node)
 
 **job.sh**
 

--- a/docs/examples/distributed/multi_node/index.md
+++ b/docs/examples/distributed/multi_node/index.md
@@ -1,7 +1,9 @@
 # Multi-Node (DDP) Job
 
 
-Prerequisites:
+**Prerequisites**
+
+Make sure to read the following sections of the documentation before using this example:
 
 * [PyTorch Setup](../../frameworks/pytorch_setup/index.md)
 * [Single GPU Job](../single_gpu/index.md)
@@ -13,7 +15,7 @@ Other interesting resources:
 * [Lambda Labs multi-node PyTorch guide](https://lambdalabs.com/blog/multi-node-pytorch-distributed-training-guide)
 
 
-Click here to see [the source code for this example](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/distributed/multi_node)
+The full source code for this example is available on [the mila-docs GitHubrepository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/distributed/multi_node)
 
 **job.sh**
 

--- a/docs/examples/distributed/multi_node/index.md
+++ b/docs/examples/distributed/multi_node/index.md
@@ -1,7 +1,6 @@
 # Multi-Node (DDP) Job
 
-
-**Prerequisites**
+## Prerequisites
 
 Make sure to read the following sections of the documentation before using this example:
 
@@ -14,6 +13,7 @@ Other interesting resources:
 * [sebarnold.net dist blog](https://sebarnold.net/dist_blog/)
 * [Lambda Labs multi-node PyTorch guide](https://lambdalabs.com/blog/multi-node-pytorch-distributed-training-guide)
 
+## Example
 
 The full source code for this example is available on [the mila-docs GitHubrepository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/distributed/multi_node)
 

--- a/docs/examples/distributed/single_gpu/index.md
+++ b/docs/examples/distributed/single_gpu/index.md
@@ -2,8 +2,8 @@
 
 
 **Prerequisites**
-Make sure to read the following sections of the documentation before using this
-example:
+
+Make sure to read the following sections of the documentation before using this example:
 
 * [PyTorch setup](../../frameworks/pytorch_setup/index.md)
 

--- a/docs/examples/distributed/single_gpu/index.md
+++ b/docs/examples/distributed/single_gpu/index.md
@@ -1,14 +1,14 @@
 # Single GPU Job
 
-
-**Prerequisites**
+## Prerequisites
 
 Make sure to read the following sections of the documentation before using this example:
 
 * [PyTorch setup](../../frameworks/pytorch_setup/index.md)
 
-The full source code for this example is available on [the mila-docs GitHub
-repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/distributed/single_gpu)
+## Example
+
+The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/distributed/single_gpu)
 
 **job.sh**
 

--- a/docs/examples/frameworks/jax/index.md
+++ b/docs/examples/frameworks/jax/index.md
@@ -1,7 +1,6 @@
 # Jax
 
-
-**Prerequisites**
+## Prerequisites
 
 Make sure to read the following sections of the documentation before using this
 example:
@@ -9,9 +8,9 @@ example:
 * [JAX setup](../jax_setup/index.md)
 * [Single GPU](../../distributed/single_gpu/index.md)
 
-The full source code for this example is available on [the mila-docs GitHub
-repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/frameworks/jax)
+## Example
 
+The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/frameworks/jax)
 
 **job.sh**
 

--- a/docs/examples/frameworks/jax_setup/index.md
+++ b/docs/examples/frameworks/jax_setup/index.md
@@ -1,7 +1,9 @@
 # Jax Setup
 
 
-**Prerequisites**: (Make sure to read the following before using this example!)
+**Prerequisites**
+
+Make sure to read the following sections of the documentation before using this example:
 
 * [Quick Start](../../../getting_started/)
 * [Running your code](../../../userguides/running_code)
@@ -35,7 +37,7 @@ This assumes that you already installed UV on the cluster you are working on.
 
 To create this environment, we first request resources for an interactive job.
 Note that we are requesting a GPU for this job, even though we're only going to
-install packages. This is because we want PyTorch to be installed with GPU
+install packages. This is because we want Jax to be installed with GPU
 support, and to have all the required libraries.
 
 ```bash

--- a/docs/examples/frameworks/jax_setup/index.md
+++ b/docs/examples/frameworks/jax_setup/index.md
@@ -1,7 +1,6 @@
 # Jax Setup
 
-
-**Prerequisites**
+## Prerequisites
 
 Make sure to read the following sections of the documentation before using this example:
 
@@ -9,9 +8,9 @@ Make sure to read the following sections of the documentation before using this 
 * [Running your code](../../../userguides/running_code)
 * [uv](../../../technical_reference/general_theory/portability/#uv)
 
-The full source code for this example is available on [the mila-docs GitHub
-repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/frameworks/jax_setup)
+## Example
 
+The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/frameworks/jax_setup)
 
 **job.sh**
 

--- a/docs/examples/frameworks/pytorch_setup/index.md
+++ b/docs/examples/frameworks/pytorch_setup/index.md
@@ -1,16 +1,15 @@
 # PyTorch Setup
 
 
-**Prerequisites**: (Make sure to read the following before using this example!)
+**Prerequisites**
 
-
-The full source code for this example is available on [the mila-docs GitHub
-repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/frameworks/pytorch_setup)
-
+Make sure to read the following sections of the documentation before using this example:
 
 * [Quick Start](../../../getting_started/)
 * [Running your code](../../../userguides/running_code)
 * [uv](../../../technical_reference/general_theory/portability/#uv)
+
+The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/frameworks/pytorch_setup)
 
 
 **job.sh**

--- a/docs/examples/frameworks/pytorch_setup/index.md
+++ b/docs/examples/frameworks/pytorch_setup/index.md
@@ -1,7 +1,6 @@
 # PyTorch Setup
 
-
-**Prerequisites**
+## Prerequisites
 
 Make sure to read the following sections of the documentation before using this example:
 
@@ -9,8 +8,9 @@ Make sure to read the following sections of the documentation before using this 
 * [Running your code](../../../userguides/running_code)
 * [uv](../../../technical_reference/general_theory/portability/#uv)
 
-The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/frameworks/pytorch_setup)
+## Example
 
+The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/frameworks/pytorch_setup)
 
 **job.sh**
 

--- a/docs/examples/good_practices/checkpointing/index.md
+++ b/docs/examples/good_practices/checkpointing/index.md
@@ -1,7 +1,6 @@
 # Checkpointing
 
-
-**Prerequisites**
+## Prerequisites
 
 Make sure to read the following sections of the documentation before using this
 example:
@@ -9,9 +8,9 @@ example:
 * [PyTorch Setup](../../frameworks/pytorch_setup/index.md)
 * [Single GPU](../../distributed/single_gpu/index.md)
 
-The full source code for this example is available on [the mila-docs GitHub
-repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/good_practices/checkpointing)
+## Example
 
+The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/good_practices/checkpointing)
 
 **job.sh**
 

--- a/docs/examples/good_practices/hpo_with_orion/index.md
+++ b/docs/examples/good_practices/hpo_with_orion/index.md
@@ -12,7 +12,7 @@ is an asynchronous framework for black-box function optimization developped at M
 Its purpose is to serve as a meta-optimizer for machine learning models and training,
 as well as a flexible experimentation platform for large scale asynchronous optimization procedures.
 
-**Prerequisites**
+## Prerequisites
 
 Make sure to read the following sections of the documentation before using this
 example:
@@ -22,8 +22,9 @@ example:
 
 The full documentation for Oríon is available [on Oríon's ReadTheDocs page](https://orion.readthedocs.io/en/stable/index.html).
 
-The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/good_practices/hpo_with_orion)
+## Example
 
+The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/good_practices/hpo_with_orion)
 
 Hyperparameter optimization is very easy to parallelize as each trial (unique set of hyperparameters) are
 independant of each other. The easiest way is to launch as many jobs as possible each trying a different

--- a/docs/examples/good_practices/launch_many_jobs/index.md
+++ b/docs/examples/good_practices/launch_many_jobs/index.md
@@ -5,8 +5,7 @@ Sometimes you may want to run the same job with different arguments.
 For example, you may want to launch an experiment using a few different learning rates.
 This example shows an easy way to do this.
 
-
-**Prerequisites**
+## Prerequisites
 
 Make sure to read the following sections of the documentation before using this
 example:
@@ -14,13 +13,14 @@ example:
 * [PyTorch Setup](../../frameworks/pytorch_setup/index.md)
 * [Single GPU](../../distributed/single_gpu/index.md)
 
+## Example
+
+The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/good_practices/launch_many_jobs)
 
 **job.sh**
 
 Compared to the [single GPU job](../../distributed/single_gpu/index.md) example, here we use the `$@` bash directive
 to pass command-line arguments down to the Python script. This makes it very easy to submit multiple jobs, each with different values!
-
-The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/good_practices/launch_many_jobs)
 
 ```diff
 --8<-- "docs/examples/good_practices/launch_many_jobs/job.sh.diff"

--- a/docs/examples/good_practices/launch_many_jobs/index.md
+++ b/docs/examples/good_practices/launch_many_jobs/index.md
@@ -7,6 +7,7 @@ This example shows an easy way to do this.
 
 
 **Prerequisites**
+
 Make sure to read the following sections of the documentation before using this
 example:
 

--- a/docs/examples/good_practices/launch_many_jobs/index.md
+++ b/docs/examples/good_practices/launch_many_jobs/index.md
@@ -18,18 +18,15 @@ example:
 **job.sh**
 
 Compared to the [single GPU job](../../distributed/single_gpu/index.md) example, here we use the `$@` bash directive
-to pass command-line arguments down to the Python script.
+to pass command-line arguments down to the Python script. This makes it very easy to submit multiple jobs, each with different values!
 
-This makes it very easy to submit multiple jobs, each with different values!
-
-The full source code for this example is available on [the mila-docs GitHub
-repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/good_practices/launch_many_jobs)
+The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/good_practices/launch_many_jobs)
 
 ```diff
 --8<-- "docs/examples/good_practices/launch_many_jobs/job.sh.diff"
 ```
 
-**Running this example**
+## Running this example
 
 You can run this example just like the [single GPU job](../../distributed/single_gpu/index.md) example, but you can now
 also pass command-line arguments directly when submitting the job with `sbatch`!
@@ -42,9 +39,7 @@ For example:
  $ sbatch job.sh --weight-decay 1e-3
 ```
 
-
-### Next steps
-
+## Next steps
 
 These next examples build on top of this one and show how to properly launch lots of jobs for hyper-parameter sweeps:
 

--- a/docs/examples/good_practices/many_tasks_per_gpu/index.md
+++ b/docs/examples/good_practices/many_tasks_per_gpu/index.md
@@ -12,15 +12,16 @@ using a combination of `sbatch` arguments. In your `sbatch` script:
 Each task will receive specific environment variables, such as `SLURM_PROCID`,
 which you can then use to parameterize the script execution.
 
-**Prerequisites**
+## Prerequisites
 
 Make sure to read the following sections of the documentation before using this
 example:
 
 * [PyTorch setup](../../frameworks/pytorch_setup/index.md)
 
-The full source code for this example is available on [the mila-docs GitHub
-repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/good_practices/many_tasks_per_gpu)
+## Example
+
+The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/good_practices/many_tasks_per_gpu)
 
 **job.sh**
 

--- a/docs/examples/good_practices/slurm_job_arrays/index.md
+++ b/docs/examples/good_practices/slurm_job_arrays/index.md
@@ -9,8 +9,7 @@ You can then slightly modify your script to choose appropriate parameter based o
 
 You can find more info about job arrays in the [SLURM official documentation page](https://slurm.schedmd.com/job_array.html).
 
-
-**Prerequisites**
+## Prerequisites
 
 Make sure to read the following sections of the documentation before using this
 example:
@@ -20,9 +19,9 @@ example:
 * [Checkpointing](../checkpointing/index.md)
 * [Many tasks per GPU](../many_tasks_per_gpu/index.md)
 
-The full source code for this example is available on [the mila-docs GitHub
-repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/good_practices/slurm_job_arrays)
+## Example
 
+The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/good_practices/slurm_job_arrays)
 
 **main.py**
 

--- a/docs/examples/good_practices/wandb_setup/index.md
+++ b/docs/examples/good_practices/wandb_setup/index.md
@@ -1,7 +1,9 @@
 # Wandb Setup
 
 
-Prerequisites:
+**Prerequisites**
+
+Make sure to read the following sections of the documentation before using this example:
 
 * [PyTorch setup](../../frameworks/pytorch_setup/index.md)
 * [Single GPU](../../distributed/single_gpu/index.md)
@@ -15,7 +17,7 @@ Other resources:
 
 * [Wandb quickstart](https://docs.wandb.ai/quickstart)
 
-Click here to see [the source code for this example](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/good_practices/wandb_setup).
+The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/good_practices/wandb_setup).
 
 **job.sh**
 

--- a/docs/examples/good_practices/wandb_setup/index.md
+++ b/docs/examples/good_practices/wandb_setup/index.md
@@ -1,7 +1,6 @@
 # Wandb Setup
 
-
-**Prerequisites**
+## Prerequisites
 
 Make sure to read the following sections of the documentation before using this example:
 
@@ -16,6 +15,8 @@ Make sure to create a Wandb account, then you can either:
 Other resources:
 
 * [Wandb quickstart](https://docs.wandb.ai/quickstart)
+
+## Example
 
 The full source code for this example is available on [the mila-docs GitHub repository.](https://github.com/mila-iqia/mila-docs/tree/master/docs/examples/good_practices/wandb_setup).
 


### PR DESCRIPTION
## Summary
* Rework the table of content of each examples in How-tos and Guides -> Minimal Examples.
  * All examples have now 3 sections : `Prerequisites`, `Example` and `Running this example`. 
* Standardize the default text of the sections `Prerequisites` and `Example` between all examples.
* Fix typo in "Jax Setup" example.