### PR TITLE
Add note on WandB CPU monitoring for DataLoader worker processes

### DIFF
--- a/docs/userguides/wandb.md
+++ b/docs/userguides/wandb.md
@@ -259,6 +259,25 @@ Two patterns indicate different root causes:
     `DataLoader`, enable `pin_memory=True`, or copy the dataset to
     `$SLURM_TMPDIR` before the job starts.
 
+    WandB monitors only the main process by default. Jobs that use
+    `DataLoader(num_workers > 0)` spawn additional Python processes whose CPU
+    usage is **not** included in the System tab metrics — so reported CPU
+    utilization may be lower than actual usage.
+
+    To include worker processes, enable process-tree monitoring:
+
+    ```python
+    wandb.init(
+        ...
+        settings=wandb.Settings(x_stats_track_process_tree=True)
+    )
+    ```
+
+    This setting has a performance overhead and is disabled by default. See the
+    [WandB settings
+    reference](https://docs.wandb.ai/models/ref/python/experiments/settings#:~:text=x_stats_track_process_tree%20(bool))
+    for details.
+
 ## Full job scripts
 
 The [`wandb_setup` example](../examples/good_practices/wandb_setup/index.md)


### PR DESCRIPTION
## Summary
Adds a note explaining that WandB only monitors the main process by default, so CPU usage from `DataLoader` workers is not reflected in the System tab. Documents how to enable process-tree monitoring via `x_stats_track_process_tree`.

## Changes
- Added a note in `docs/userguides/wandb.md` under the high-CPU / DataLoader pattern explaining the monitoring gap.
- Includes a code snippet showing how to pass `settings=wandb.Settings(x_stats_track_process_tree=True)` to `wandb.init`.
- Links to the WandB settings reference for the flag.

## Notes
The setting carries a performance overhead and is off by default — this is called out explicitly in the added text.

resolves #420