### PR TITLE
Standardize section headers in "General Theory"

### DIFF
--- a/docs/technical_reference/general_theory/batch_scheduling.md
+++ b/docs/technical_reference/general_theory/batch_scheduling.md
@@ -1,4 +1,4 @@
-## The workload manager
+# The workload manager
 
 On a cluster, users don't have direct access to the compute nodes but
 instead connect to a login node and add jobs to the workload manager
@@ -6,7 +6,7 @@ queue. Whenever there are resources available to execute these jobs
 they will be allocated to a compute node and run, which can be
 immediately or after a wait of up to several days.
 
-### Anatomy of a job
+## Anatomy of a job
 
 A job is comprised of a number of steps that will run one after the
 other. This is done so that you can schedule a sequence of processes
@@ -36,7 +36,7 @@ If this all seems complicated, you should know that all these things
 do not need to always be used. It is perfectly acceptable to sumbit
 jobs with a single step, a single task and a single process.
 
-### Understanding the queue
+## Understanding the queue
 
 The available resources on the cluster are not infinite and it is the
 workload manager's job to allocate them. Whenever a job request comes
@@ -53,7 +53,7 @@ things. There should be a tool that comes with the manager where you
 can see the status of your queued jobs and why they remain in the
 queue.
 
-### About partitions
+## About partitions
 
 The workload manager will divide the cluster into partitions according
 to the configuration set by the admins. A partition is a set of
@@ -72,7 +72,7 @@ type blocking use of another. They are also useful for heterogenous
 clusters where different hardware is mixed in and not all software is
 compatible with all of it (for example x86 and POWER cpus).
 
-### Exceding limits (preemption and grace periods)
+## Exceding limits (preemption and grace periods)
 
 To ensure a fair share of the computing resources for all, the workload
 manager establishes limits on the amount of resources that a single
@@ -104,7 +104,7 @@ unavailable. For others, like RAM, usage is monitored and your job
 will be terminated if it goes too much over. This makes it important
 to ensure you estimate resource usage accurately.
 
-### Mila information
+## Mila information
 
 **Mila** as well as 
 [Digital Research Alliance of Canada](https://docs.alliancecan.ca/wiki/Technical_documentation) 

--- a/docs/technical_reference/general_theory/cluster_parts.md
+++ b/docs/technical_reference/general_theory/cluster_parts.md
@@ -1,4 +1,4 @@
-## What is a computer cluster?
+# What is a computer cluster?
 
 A [computer cluster](https://en.wikipedia.org/wiki/Computer_cluster) is a set
 of loosely or tightly connected computers that work together so that, in many

--- a/docs/technical_reference/general_theory/data.md
+++ b/docs/technical_reference/general_theory/data.md
@@ -1,10 +1,10 @@
-## Processing data
+# Processing data
 
 For processing large amounts of data common for deep learning, either
 for dataset preprocessing or training, several techniques exist. Each
 has typical uses and limitations.
 
-### Data parallelism
+## Data parallelism
 
 The first technique is called **data parallelism** (aka task
 parallelism in formal computer science). You simply run lots of
@@ -29,7 +29,7 @@ and the compute nodes and if you run too many jobs using too much data
 at once they may end up not being any faster because they will spend
 their time waiting for data to arrive.
 
-### Model parallelism
+## Model parallelism
 
 The second technique is called **model parallelism** (which doesn't
 have a single equivalent in formal computer science). It is used
@@ -44,7 +44,7 @@ with each other to arrive at a final result.
 This is generally harder but necessary to work with larger, more
 powerful models like GPT.
 
-### Communication concerns
+## Communication concerns
 
 The main difference of these two approaches is the need for
 communication between the multiple processes. Some common training
@@ -69,7 +69,7 @@ support (such as [InfiniBand ](https://en.wikipedia.org/wiki/InfiniBand),
 [RDMA ](https://en.wikipedia.org/wiki/Remote_direct_memory_access),
 [NVLink ](https://en.wikipedia.org/wiki/NVLink) or others)
 
-### Filesystem concerns
+## Filesystem concerns
 
 When working on a cluster, you will generally encounter several
 different filesystems.  Usually there will be names such as 'home',

--- a/docs/technical_reference/general_theory/software_deps.md
+++ b/docs/technical_reference/general_theory/software_deps.md
@@ -1,4 +1,4 @@
-## Software on the cluster
+# Software on the cluster
 
 This section aims to raise awareness to problems one can encounter when trying
 to run a software on different computers and how this is dealt with on typical
@@ -12,7 +12,7 @@ with your desired software and run them on compute nodes.
 Regarding Python development, we recommend using virtual environments to install
 Python packages in isolation.
 
-### Cluster software modules
+## Cluster software modules
 
 Modules are small files which modify your environment variables to point to
 specific versions of various software and libraries. For instance, a module
@@ -22,7 +22,7 @@ on.
 
 For more information, see [The module command](../../../technical_reference/clusters/drac/#modules).
 
-### Containers
+## Containers
 
 Containers are a special form of isolation of software and its dependencies. A
 container is essentially a lightweight virtual machine: it encapsulates a
@@ -37,7 +37,7 @@ be run on any compatible system.
 For more information, see [Using containers](../../../technical_reference/general_theory/containers).
 
 
-### Python Virtual environments
+## Python Virtual environments
 
 A virtual environment in Python is a local, isolated environment in which you
 can install or uninstall Python packages without interfering with the global

--- a/docs/technical_reference/general_theory/unix.md
+++ b/docs/technical_reference/general_theory/unix.md
@@ -1,4 +1,4 @@
-## UNIX
+# Unix
 
 All clusters typically run on GNU/Linux distributions. Hence a minimum
 knowledge of GNU/Linux and BASH is usually required to use them. See the


### PR DESCRIPTION
## Summary
* Fix duplicated titles in header and in the table of contents.

### Examples
Before :
<img width="940" height="236" alt="Capture d’écran, le 2026-06-05 à 15 00 07" src="https://github.com/user-attachments/assets/f5459cc8-e7ca-4219-affb-93842aacfc73" />

After :
<img width="937" height="206" alt="Capture d’écran, le 2026-06-05 à 15 00 18" src="https://github.com/user-attachments/assets/4f46dd9f-2340-4240-a395-5eaa35e46c77" />
