### PR TITLE
Disable the ai assistant from the search bar

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -73,12 +73,12 @@ and we'll take a look at it!
             const url = hash ? `${urlWithQuery}#${hash}` : urlWithQuery;
             return html`<a href="${url}">${children}</a>`;
         },
-        // Agent Studio configuration
-        askAi: {
-            assistantId: "d9b031b9-047c-4b63-a794-010d037dce19",
-            agentStudio: true,
-            // suggestedQuestions: true,
-        },
+        // // Agent Studio configuration
+        // askAi: {
+        //     assistantId: "d9b031b9-047c-4b63-a794-010d037dce19",
+        //     agentStudio: true,
+        //     // suggestedQuestions: true,
+        // },
         theme: theme,
     });
 


### PR DESCRIPTION
This would help to avoid starting an AI assistant discussion when the user only wants to search for `"mila code"`

Before :

<img width="1600" height="1166" alt="Capture d’écran 2026-06-11 à 10 44 56" src="https://github.com/user-attachments/assets/9ef1e96f-e063-4696-9694-2d47c0b33c16" />

After :

<img width="1600" height="984" alt="Capture d’écran 2026-06-11 à 10 45 44" src="https://github.com/user-attachments/assets/309988ea-4d88-453a-ba1d-ce7b9e3f23a3" />