### PR TITLE
Standardize GPU efficiency guide: structure, tone, and Title Case

### DIFF
--- a/docs/userguides/gpu_efficiency.md
+++ b/docs/userguides/gpu_efficiency.md
@@ -55,10 +55,13 @@ In other words, efficient compute utilization makes Mila research thrive.
 ## The basics of compute efficiency: utilization vs. occupancy
 
 `nvidia-smi` is a useful first check, but its utilization metric has
-limitations: it reports "100% Utilization" as soon as any kernel is running
-on the GPU, regardless of how much of the hardware is actually in use. For a
-more precise view, look at **Streaming Multiprocessor (SM) Occupancy**, which
-measures what fraction of the GPU's computing units are actively working.
+limitations: it reports "100% Utilization" as soon as any kernel is running on
+the GPU, regardless of how much of the hardware is actually in use. So if the
+reported GPU utilization is low or equals zero, it usually means there is room
+for optimization. For a more precise view, look at **Streaming Multiprocessor
+(SM) Occupancy**, which measures what fraction of the GPU's computing units are
+actively working. More context is available in this [external post on GPU
+utilization metrics](https://www.trainy.ai/blog/gpu-utilization-misleading).
 
 Use the table below as a reference to evaluate SM occupancy:
 
@@ -77,7 +80,7 @@ the underlying numbers.
 
 ```mermaid
 flowchart TD
-    A[Suspect a job is underutilized] --> B{SM occupancy ≥ 30%?}
+    A[Suspect a job's resources are underutilized] --> B{SM occupancy ≥ 30%?}
     B -->|Yes| C[GPU well utilized — no action needed]
     B -->|No| D{VRAM usage < 20%?}
     D -->|Yes| E[Increase batch size, use a smaller GPU, or pack jobs]
@@ -132,13 +135,13 @@ for efficient GPU utilization.
       interactive partitions while away from the keyboard. Release them if not
       actively computing.
     - **Avoiding preemption queues:** Do not camp on non-preemptible partitions
-      just to avoid writing checkpointing code — this tanks overall queue
-      priority.
+      to avoid writing checkpointing code — this significantly reduces
+      overall queue priority.
     - **Over-allocating CPU cores:** Do not request excessive CPU cores (e.g.,
       40 CPUs for 1 GPU) unless preprocessing explicitly requires it. Mila
       provides CPU-only nodes if needed.
-    - **Scaling GPUs to fix I/O bottlenecks:** Do not add more GPUs if the
-      pipeline is bottlenecked by storage read latency or CPU preprocessing —
+    - **Scaling GPUs to fix I/O bottlenecks:** Do not add more GPUs if
+      storage read latency or CPU preprocessing bottlenecks the pipeline —
       this only idles more hardware.
     - **Underutilizing VRAM:** If VRAM usage is under 20%, consider increasing
       batch size, switching to a smaller GPU, or using job packing (multiple

--- a/docs/userguides/gpu_efficiency.md
+++ b/docs/userguides/gpu_efficiency.md
@@ -82,8 +82,8 @@ flowchart TD
     B -->|No| D{VRAM usage < 20%?}
     D -->|Yes| E[Increase batch size, use a smaller GPU, or pack jobs]
     D -->|No| F{Data loader saturating the GPU?}
-    F -->|No| G[Tune the DataLoader: num_workers, pin_memory]
-    F -->|Yes| H[Profile for I/O or CPU preprocessing bottleneck]
+    F -->|Yes| G[Profile for I/O or CPU preprocessing bottleneck]
+    F -->|No| H[Tune the DataLoader: num_workers, pin_memory]
 ```
 
 ### Method A: Weights & Biases

--- a/docs/userguides/gpu_efficiency.md
+++ b/docs/userguides/gpu_efficiency.md
@@ -1,26 +1,58 @@
 ---
-title: "Could my job run faster? How to identify GPU waste"
+title: "Could My Job Run Faster? How to Identify GPU Waste"
 description: >-
   Understand GPU efficiency metrics, diagnose underutilization in your jobs,
   and apply concrete best practices to improve throughput on the Mila cluster.
 ---
 
-# Could my job run faster? How to identify GPU waste
+# Could My Job Run Faster? How to Identify GPU Waste
 
-## Why should you care about GPU efficiency?
+This guide explains how to read GPU efficiency metrics, diagnose an
+underutilized job, and apply concrete best practices to improve throughput on
+the Mila cluster.
 
-Optimizing your GPU usage directly accelerates research velocity. As compute
-power at Mila is a shared resource, efficient jobs on the cluster bring a
-two-sided advantage:
+## Before you begin
 
-- **For you:** Eliminating bottlenecks speeds up your training times and helps
-  unearth hidden bugs in your data loaders or model architectures. With properly sized compute requests and efficient utilization, your jobs will be started sooner and will get suseful results faster.
+<div class="grid cards" markdown>
+
+-   [:material-monitor:{ .lg .middle } __Monitor runs with WandB__](wandb.md)
+    { .card }
+
+    ---
+    Track GPU utilization, CPU usage, and memory for a run.
+
+-   [:material-server:{ .lg .middle } __Slurm basics__](slurm_guide/basics.md)
+    { .card }
+
+    ---
+    Submit and allocate jobs on the cluster.
+
+</div>
+
+## What this guide covers
+
+* Compute efficiency concepts: utilization vs. occupancy
+* How to diagnose an underutilized job
+* Best practices for efficient GPU use on the cluster
+
+---
+
+## Why GPU efficiency matters
+
+Optimizing GPU usage directly accelerates research velocity. As compute power
+at Mila is a shared resource, efficient jobs on the cluster bring a two-sided
+advantage:
+
+- **For the researcher:** Eliminating bottlenecks speeds up training times and
+  helps unearth hidden bugs in data loaders or model architectures. With
+  properly sized compute requests and efficient utilization, jobs start sooner
+  and produce useful results faster.
 - **For Mila:** Maximizing efficiency frees up cluster nodes, resulting in
   shorter queue times and more parallel experiments across the institute.
 
 In other words, efficient compute utilization makes Mila research thrive.
 
-## The basics of compute efficiency: Utilization vs. Occupancy
+## The basics of compute efficiency: utilization vs. occupancy
 
 `nvidia-smi` is a useful first check, but its utilization metric has
 limitations: it reports "100% Utilization" as soon as any kernel is running
@@ -28,7 +60,7 @@ on the GPU, regardless of how much of the hardware is actually in use. For a
 more precise view, look at **Streaming Multiprocessor (SM) Occupancy**, which
 measures what fraction of the GPU's computing units are actively working.
 
-Use the table below as a reference to evaluate your SM occupancy:
+Use the table below as a reference to evaluate SM occupancy:
 
 | SM Occupancy | Assessment |
 |---|---|
@@ -37,20 +69,33 @@ Use the table below as a reference to evaluate your SM occupancy:
 | ~30% | Good utilization |
 | ≥ 50% | Great / optimized utilization |
 
-## How to diagnose your jobs today?
+## How to diagnose a job
 
-You can self-diagnose using these framework-agnostic methods.
+Self-diagnosis is possible using these framework-agnostic methods. The
+flowchart below outlines the decision path; Methods A and B explain how to read
+the underlying numbers.
+
+```mermaid
+flowchart TD
+    A[Suspect a job is underutilized] --> B{SM occupancy ≥ 30%?}
+    B -->|Yes| C[GPU well utilized — no action needed]
+    B -->|No| D{VRAM usage < 20%?}
+    D -->|Yes| E[Increase batch size, use a smaller GPU, or pack jobs]
+    D -->|No| F{Data loader saturating the GPU?}
+    F -->|No| G[Tune the DataLoader: num_workers, pin_memory]
+    F -->|Yes| H[Profile for I/O or CPU preprocessing bottleneck]
+```
 
 ### Method A: Weights & Biases
 
-If you use WandB, go to the **System** tab of your run to find data on GPU
-utilization, CPU usage, and memory. See
+In WandB, the **System** tab of a run shows data on GPU utilization, CPU
+usage, and memory. See
 [Diagnose training bottlenecks](wandb.md#diagnose-training-bottlenecks)
 for details.
 
 ### Method B: The interactive check
 
-During a job, you can `srun` into your allocated node and run a basic check:
+During a job, `srun` into the allocated node and run a basic check:
 
 ```bash
 # Check GPU utilization and power draw
@@ -59,57 +104,92 @@ nvidia-smi
 # High power draw (Watts) is usually a good signal of active GPU utilization.
 ```
 
-## Typical DOs and DON'Ts of compute efficiency
+## Best practices for efficient GPU use
 
-Even if situations are very diverse, the following guidelines pave the way for
-efficient GPU utilization.
+Even though situations are diverse, the following guidelines pave the way
+for efficient GPU utilization.
 
-### ✅ DOs — To improve your runs
+!!! tip "Do — improve efficiency"
+    - **Profile before scaling:** Run a test job with a profiler (WandB or
+      TensorBoard) before launching large sweeps to ensure the data loader
+      saturates the GPU.
+    - **Optimize data pipelines:** Set `num_workers > 0` (2–4 per allocated
+      GPU) and enable `pin_memory=True` in the PyTorch `DataLoader` to prevent
+      GPU stalling.
+    - **Implement checkpointing:** Save training states regularly so jobs
+      resume automatically after preemption or timeouts without losing previous
+      compute hours.
+    - **Right-size resource requests:** Use
+      [lower-tier nodes](../technical_reference/clusters/mila/nodes.md) (e.g.,
+      RTX8000, V100) or MIG (Multi-Instance GPU) slices for small models or
+      debugging instead of allocating full high-end nodes.
+    - **Request minimal compute blocks:** When possible, request the smallest
+      allocation that fits the job. Smaller allocations fill queue gaps faster,
+      reducing wait time.
 
-1. **Profile before scaling:** Run a test job with a profiler (WandB or
-   TensorBoard) before launching large sweeps to ensure your data loader
-   saturates the GPU.
-2. **Optimize data pipelines:** Set `num_workers > 0` (2–4 per allocated GPU)
-   and enable `pin_memory=True` in your PyTorch `DataLoader` to prevent GPU
-   stalling.
-3. **Implement checkpointing:** Save training states regularly so jobs can
-   automatically resume after preemption or timeouts without losing previous
-   compute hours.
-4. **Right-size resource requests:** Use
-   [lower-tier nodes](https://docs.mila.quebec/technical_reference/clusters/mila/nodes/)
-   (e.g., RTX8000, V100) or MIG (Multi-Instance GPU) slices for small models
-   or debugging instead of allocating full high-end nodes.
-5. **Request minimal compute blocks:** When possible, request the smallest
-   allocation that fits your job. Smaller allocations fill queue gaps faster,
-   reducing your wait time.
+!!! warning "Don't — common pitfalls"
+    - **Hoarding nodes:** Do not keep high-end GPUs (e.g., H100s) allocated on
+      interactive partitions while away from the keyboard. Release them if not
+      actively computing.
+    - **Avoiding preemption queues:** Do not camp on non-preemptible partitions
+      just to avoid writing checkpointing code — this tanks overall queue
+      priority.
+    - **Over-allocating CPU cores:** Do not request excessive CPU cores (e.g.,
+      40 CPUs for 1 GPU) unless preprocessing explicitly requires it. Mila
+      provides CPU-only nodes if needed.
+    - **Scaling GPUs to fix I/O bottlenecks:** Do not add more GPUs if the
+      pipeline is bottlenecked by storage read latency or CPU preprocessing —
+      this only idles more hardware.
+    - **Underutilizing VRAM:** If VRAM usage is under 20%, consider increasing
+      batch size, switching to a smaller GPU, or using job packing (multiple
+      smaller jobs on the same node).
 
-### ❌ DON'Ts — Common pitfalls
+---
 
-1. **Hoarding nodes:** Do not keep high-end GPUs (e.g., H100s) allocated on
-   interactive partitions while away from your keyboard. Release them if not
-   actively computing.
-2. **Avoiding preemption queues:** Do not camp on non-preemptible partitions
-   just to avoid writing checkpointing code — this tanks your overall queue
-   priority.
-3. **Over-allocating CPU cores:** Do not request excessive CPU cores (e.g., 40
-   CPUs for 1 GPU) unless your preprocessing explicitly requires it. Mila
-   provides CPU-only nodes if needed.
-4. **Scaling GPUs to fix I/O bottlenecks:** Do not add more GPUs if your
-   pipeline is bottlenecked by storage read latency or CPU preprocessing — you
-   will just idle more hardware.
-5. **Underutilizing VRAM:** If your VRAM usage is under 20%, consider increasing
-   batch size, switching to a smaller GPU or using job packing (multiple smaller
-   jobs on the same node).
+## Key concepts
+
+**SM Occupancy**
+:   The fraction of a GPU's Streaming Multiprocessors (computing units) that
+    are actively working. A more precise measure of GPU use than the
+    `nvidia-smi` utilization metric.
+
+**GPU Utilization**
+:   The `nvidia-smi` metric that reports 100% as soon as any kernel runs on the
+    GPU, regardless of how much hardware is in use. Useful as a first check but
+    misleading on its own.
+
+**MIG (Multi-Instance GPU)**
+:   A feature that partitions a single GPU into smaller isolated slices, well
+    suited to small models or debugging.
+
+**VRAM**
+:   The GPU's onboard memory. Low VRAM usage often signals room to increase
+    batch size or move to a smaller GPU.
+
+## Next steps
+
+<div class="grid cards" markdown>
+
+-   [:material-monitor:{ .lg .middle } __Diagnose training bottlenecks__](wandb.md#diagnose-training-bottlenecks)
+    { .card }
+
+    ---
+    Use the WandB System tab to locate GPU, CPU, and I/O bottlenecks.
+
+-   [:material-server:{ .lg .middle } __Right-size node requests__](../technical_reference/clusters/mila/nodes.md)
+    { .card }
+
+    ---
+    Choose an appropriate node tier for the job.
+
+</div>
 
 ## Get help
 
-If you have any questions, feel free to reach out on Slack
-(`#mila-cluster`, `#compute-canada`), or drop by during
-[Office Hours](https://docs.mila.quebec/help/office_hours/).
-We are always happy to provide early guidance or share thoughts on how to
-improve your experiments — in the interest of the community.
+Questions are welcome on Slack (`#mila-cluster`, `#compute-canada`), or during
+[Office Hours](https://docs.mila.quebec/help/office_hours/). The team is always
+happy to provide early guidance or share thoughts on how to improve
+experiments — in the interest of the community.
 
-You can also use an LLM with
-[curated Mila cluster context](https://docs.mila.quebec/ai/) to investigate
-and remove obvious performance issues if you prefer to take matters into your
-own hands.
+An LLM with [curated Mila cluster context](https://docs.mila.quebec/ai/) can
+also help investigate and remove performance issues.


### PR DESCRIPTION
## Summary
Restructures the GPU efficiency guide for scannability and consistency with Mila docs standards, adding navigation aids and a diagnostic flowchart without changing the underlying guidance.

## Changes
- Switch title and key headings to Title Case; rewrite intro to a neutral, guide-style voice (removes "you your" in favor of direct/impersonal phrasing).
- Add "Before you begin" and "Next steps" card grids linking to WandB monitoring and Slurm basics / node sizing docs.
- Add a "What this guide covers" bullet summary.
- Add a Mermaid flowchart to `How to diagnose a job` showing the decision path (SM occupancy → VRAM → data loader → I/O/CPU bottleneck).
- Convert the DOs/DON'Ts lists into `!!! tip` / `!!! warning` admonition blocks.
- Add a "Key concepts" glossary (SM Occupancy, GPU Utilization, MIG, VRAM).
- Fix internal links (`wandb.md`, `../technical_reference/clusters/mila/nodes.md`) to relative paths.

## Notes
Content/guidance is unchanged — this is a formatting and structure pass on `docs/userguides/gpu_efficiency.md`.