### PR TITLE
Fix broken docs links/anchors and fail the build on regressions

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -28,4 +28,4 @@ build:
 
 mkdocs:
   configuration: mkdocs.yml
-  fail_on_warning: false
+  fail_on_warning: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ description: Technical documentation for Mila's computing infrastructure.
 # Mila technical documentation
 
 Welcome to Mila's technical documentation. If this is your first time here, we
-recommend you start by checking out the [short quick start guide](getting_started/).
+recommend you start by checking out the [short quick start guide](getting_started/index.md).
 
 
 <div class="grid cards" markdown>
@@ -19,7 +19,7 @@ recommend you start by checking out the [short quick start guide](getting_starte
 
     Learn to log in to the cluster, run your first job, and train your first mode
 
-    [:octicons-arrow-right-24: Getting started](getting_started)
+    [:octicons-arrow-right-24: Getting started](getting_started/index.md)
 
 
 
@@ -29,7 +29,7 @@ recommend you start by checking out the [short quick start guide](getting_starte
 
     Discover more advanced guides to help you in your research
 
-    [:octicons-arrow-right-24: Learn new things](userguides)
+    [:octicons-arrow-right-24: Learn new things](userguides/index.md)
 
 
 -   :material-robot:{ .lg .middle } __AI agents__
@@ -38,7 +38,7 @@ recommend you start by checking out the [short quick start guide](getting_starte
 
     Powercharge your workflow with AI coding tools tailored for Mila researchers
 
-    [:octicons-arrow-right-24: Explore AI agents](ai)
+    [:octicons-arrow-right-24: Explore AI agents](ai/index.md)
 
 
 -   :material-book-open-page-variant:{ .lg .middle } __Technical reference__
@@ -47,7 +47,7 @@ recommend you start by checking out the [short quick start guide](getting_starte
 
     Find advanced notions to better understand how everything works
 
-    [:octicons-arrow-right-24: Dig deeper](technical_reference)
+    [:octicons-arrow-right-24: Dig deeper](technical_reference/index.md)
 
     [:octicons-arrow-right-24: About the Mila Cluster](technical_reference/clusters/mila/)
 
@@ -57,7 +57,7 @@ recommend you start by checking out the [short quick start guide](getting_starte
 
     Obtain tools for your projects
 
-    [:octicons-arrow-right-24: Browse the tools](toolbox)
+    [:octicons-arrow-right-24: Browse the tools](toolbox/index.md)
 
 -   :material-account-question:{ .lg .middle } __Get help__
 
@@ -69,7 +69,7 @@ recommend you start by checking out the [short quick start guide](getting_starte
 
     [:octicons-arrow-right-24: Ask your question to IT support](https://mila-iqia.atlassian.net/servicedesk/customer/portal/5)
     
-    [:octicons-arrow-right-24: {% include-markdown "generated_from_config/office_hours_short.md" %}](help/office_hours/)
+    [:octicons-arrow-right-24: {% include-markdown "generated_from_config/office_hours_short.md" %}](help/office_hours.md)
 
 
 -   :material-bookmark:{ .lg .middle } __Cheatsheet__

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,7 @@ recommend you start by checking out the [short quick start guide](getting_starte
 
     [:octicons-arrow-right-24: Dig deeper](technical_reference/index.md)
 
-    [:octicons-arrow-right-24: About the Mila Cluster](technical_reference/clusters/mila/)
+    [:octicons-arrow-right-24: About the Mila Cluster](technical_reference/clusters/mila/index.md)
 
 -   :material-hammer-wrench:{ .lg .middle } __Toolbox__
 

--- a/docs/ai/context.md
+++ b/docs/ai/context.md
@@ -51,7 +51,7 @@ Or download manually on GitHub:
 2. Click [`all_docs_condensed.md`](https://github.com/mila-iqia/mila-docs/blob/master/all_docs_condensed.md) in the file list.
 3. Click the **Download raw file** button, on the upper right corner of the file.
 
-    ![Download Github file](../../_static/images/download_github_file.png)
+    ![Download Github file](../_static/images/download_github_file.png)
 
 ## Load the file into a chat session
 
@@ -61,7 +61,7 @@ Most LLM chat assistants accept either file uploads or large text pastes.
 
     1. Open a new conversation at [claude.ai](https://claude.ai).
     2. Click the **paperclip** icon.
-        ![Provide file to Claude LLM](../../_static/images/llm_provide_file_claude.png)
+        ![Provide file to Claude LLM](../_static/images/llm_provide_file_claude.png)
 
     3. Select `all_docs_condensed.md` from the local filesystem.
     4. Add a context message alongside the file upload:
@@ -79,7 +79,7 @@ Most LLM chat assistants accept either file uploads or large text pastes.
     1. Open a new conversation at [chatgpt.com](https://chatgpt.com)
         using GPT-4o or a later model.
     2. Click the **paperclip** icon.
-        ![Provide file to ChatGPT](../../_static/images/llm_provide_file_chatgpt.png)
+        ![Provide file to ChatGPT](../_static/images/llm_provide_file_chatgpt.png)
     3. Select `all_docs_condensed.md` from the local filesystem.
     4. Add a context message alongside the upload:
 
@@ -95,7 +95,7 @@ Most LLM chat assistants accept either file uploads or large text pastes.
 
     1. Open a new conversation at [gemini.google.com](https://gemini.google.com).
     2. Click the **attachment** icon.
-        ![Provide file to Gemini](../../_static/images/llm_provide_file_gemini.png)
+        ![Provide file to Gemini](../_static/images/llm_provide_file_gemini.png)
     3. Select `all_docs_condensed.md` from the local filesystem.
     4. Add a context message alongside the upload:
 

--- a/docs/examples/frameworks/flash_attn_setup/index.md
+++ b/docs/examples/frameworks/flash_attn_setup/index.md
@@ -17,9 +17,9 @@ wheel is available.
 
 Make sure to read the following sections of the documentation before using this example:
 
-* [Quick Start](../../../getting_started/train_first_model/)
-* [Running your code](../../../userguides/running_code)
-* [uv](../../../technical_reference/general_theory/portability/#uv)
+* [Quick Start](../../../getting_started/train_first_model.md)
+* [Running your code](../../../technical_reference/general_theory/slurm.md)
+* [uv](../../../technical_reference/general_theory/portability.md#uv)
 
 Other resources:
 

--- a/docs/examples/frameworks/index.md
+++ b/docs/examples/frameworks/index.md
@@ -5,7 +5,7 @@
 {% include-markdown "examples/header.md" start="<!-- START -->" %}
 
 This section shows how to setup a development environment for various frameworks.
-These examples use [uv](../../technical_reference/general_theory/portability/#uv) to create a virtual environment and manage dependencies.
+These examples use [uv](../../technical_reference/general_theory/portability.md#uv) to create a virtual environment and manage dependencies.
 
 - [PyTorch Setup](pytorch_setup/index.md)
 - [Jax Setup](jax_setup/index.md)

--- a/docs/examples/frameworks/jax_setup/index.md
+++ b/docs/examples/frameworks/jax_setup/index.md
@@ -4,9 +4,9 @@
 
 Make sure to read the following sections of the documentation before using this example:
 
-* [Quick Start](../../../getting_started/train_first_model/)
-* [Running your code](../../../userguides/running_code)
-* [uv](../../../technical_reference/general_theory/portability/#uv)
+* [Quick Start](../../../getting_started/train_first_model.md)
+* [Running your code](../../../technical_reference/general_theory/slurm.md)
+* [uv](../../../technical_reference/general_theory/portability.md#uv)
 
 ## Example
 

--- a/docs/examples/frameworks/pytorch_setup/index.md
+++ b/docs/examples/frameworks/pytorch_setup/index.md
@@ -4,9 +4,9 @@
 
 Make sure to read the following sections of the documentation before using this example:
 
-* [Quick Start](../../../getting_started/train_first_model/)
-* [Running your code](../../../userguides/running_code)
-* [uv](../../../technical_reference/general_theory/portability/#uv)
+* [Quick Start](../../../getting_started/train_first_model.md)
+* [Running your code](../../../technical_reference/general_theory/slurm.md)
+* [uv](../../../technical_reference/general_theory/portability.md#uv)
 
 ## Example
 

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -18,7 +18,9 @@ skills:
 This guide covers obtaining a Mila account, connecting to the cluster, and
 setting up the tools needed to run jobs. Follow the steps in order.
 
-## Before you begin { #obtain-your-mila-account #enable-your-cluster-access #install-wsl }
+## Before you begin
+
+[](){ #obtain-your-mila-account }
 
 ???+ success "Obtain your Mila account (`@mila.quebec`)"
 
@@ -32,6 +34,8 @@ setting up the tools needed to run jobs. Follow the steps in order.
         If this takes longer than expected, contact [MyMila
         support](https://mila-iqia.atlassian.net/servicedesk/customer/portal/8).
 
+[](){ #enable-your-cluster-access }
+
 ???+ success "Enable your cluster access"
 
     1. Read the [IT Onboarding
@@ -41,6 +45,8 @@ setting up the tools needed to run jobs. Follow the steps in order.
        on Slack, including the cluster username. Cluster access can take up to
        48 hours to become effective.
     3. IT will send an email to activate Multi-Factor Authentication.
+
+[](){ #install-wsl }
 
 ???+ warning ":material-microsoft-windows-classic: Windows users: install WSL first"
 

--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -48,7 +48,7 @@ Need a hand getting your experiments running on the cluster? You'll find everyth
 
     Your answers may be in the **FAQ page**
 
-    [:octicons-arrow-right-24: Check the FAQ](../help/faq)
+    [:octicons-arrow-right-24: Check the FAQ](faq.md)
     
 -   :material-robot:{ .lg .middle } __Ask an AI agent__
 
@@ -84,7 +84,7 @@ Need a hand getting your experiments running on the cluster? You'll find everyth
 
     They also take place online at the same dates: the virtual invite is on the Mila-core calendar.
 
-    [:octicons-arrow-right-24: Join us at the Office Hours](../help/office_hours/)
+    [:octicons-arrow-right-24: Join us at the Office Hours](office_hours.md)
 
 
 </div>
@@ -105,7 +105,7 @@ If you've checked the docs and still need assistance, we've got your back! To ge
 |------|-----------------|----------------|
 | MyMila | Community Integration. General administrative onboarding and community-related inquiries. | [MyMila Portal](https://portal.mila.quebec/) |
 | IT Support | Technical Onboarding & Access. Account creation, **SSH issues**, VPN, hardware, and access management. | [Portal](https://it-support.mila.quebec) or Slack ([#mila-cluster](https://mila-umontreal.slack.com/archives/CFAS8455H), [#tamia-cluster](https://mila-umontreal.slack.com/archives/C08KMD8FJNA), [#compute-canada](https://mila-umontreal.slack.com/archives/C2TL9FRBP)) |
-| IDT | Computing expertise. Debug your jobs, optimize your experiments, remove cluster hurdles. | Slack ([#mila-cluster](https://mila-umontreal.slack.com/archives/CFAS8455H), [#tamia-cluster](https://mila-umontreal.slack.com/archives/C08KMD8FJNA), [#compute-canada](https://mila-umontreal.slack.com/archives/C2TL9FRBP)) or [IDT Office Hours (Lab A)](office_hours) |
+| IDT | Computing expertise. Debug your jobs, optimize your experiments, remove cluster hurdles. | Slack ([#mila-cluster](https://mila-umontreal.slack.com/archives/CFAS8455H), [#tamia-cluster](https://mila-umontreal.slack.com/archives/C08KMD8FJNA), [#compute-canada](https://mila-umontreal.slack.com/archives/C2TL9FRBP)) or [IDT Office Hours (Lab A)](office_hours.md) |
 
 ## 3. Reach out
 

--- a/docs/singularity/index.md
+++ b/docs/singularity/index.md
@@ -47,7 +47,7 @@ You can find most of them on `dockerhub`_.
 .. _dockerhub: https://hub.docker.com/
 
 > **tip:**
-        (Optional) You can also pull containers from nvidia cloud see [nvidia](#nvidia)
+        (Optional) You can also pull containers from nvidia cloud see [nvidia](nvidia.md)
 
 Go on `dockerhub`_ and select the container you want to pull.
 

--- a/docs/technical_reference/clusters/index.md
+++ b/docs/technical_reference/clusters/index.md
@@ -1,14 +1,12 @@
 # Clusters
 
-<!-- Static links are here temporarily -->
-
 | Clusters | Maintainer | Portal | More details (allocations, resources...) |
 | -------- | ---------- | ------ | ---------------------------------------- |
-| [Mila](https://docs.mila.quebec/technical_reference/clusters/mila/) | Mila | - | [Resources](https://docs.mila.quebec/technical_reference/clusters/mila/nodes/) |
-| [Fir](https://docs.mila.quebec/technical_reference/clusters/drac/#fir) | DRAC | - | [More details](https://docs.alliancecan.ca/wiki/Fir/en) |
-| [Nibi](https://docs.mila.quebec/technical_reference/clusters/drac/#nibi) | DRAC | [Nibi portal](https://portal.nibi.sharcnet.ca/) | [More details](https://docs.alliancecan.ca/wiki/Nibi/en) |
-| [Rorqual](https://docs.mila.quebec/technical_reference/clusters/drac/#rorqual) | DRAC | [Rorqual portal](https://metrix.rorqual.calculquebec.ca/) | [More details](https://docs.alliancecan.ca/wiki/Rorqual/en) |
-| [Trillium](https://docs.mila.quebec/technical_reference/clusters/drac/#trillium) | DRAC | [Trillium portal](https://my.scinet.utoronto.ca/) | [More details](https://docs.alliancecan.ca/wiki/Trillium/en) |
-| [TamIA](https://docs.mila.quebec/technical_reference/clusters/paice#tamia) | PAICE | [TamIA portal](https://portail.tamia.ecpia.ca/) | [More details](https://docs.alliancecan.ca/wiki/TamIA/en) |
-| [Killarney](https://docs.mila.quebec/technical_reference/clusters/paice/#killarney) | PAICE | - | [More details](https://docs.alliancecan.ca/wiki/Killarney/en) |
-| [Vulcan](https://docs.mila.quebec/technical_reference/clusters/paice/#vulcan) | PAICE | [Vulcan portal](https://portal.vulcan.alliancecan.ca/) | [More details](https://docs.alliancecan.ca/wiki/Vulcan/en) |
+| [Mila](mila/index.md) | Mila | - | [Resources](mila/nodes.md) |
+| [Fir](drac/index.md#fir) | DRAC | - | [More details](https://docs.alliancecan.ca/wiki/Fir/en) |
+| [Nibi](drac/index.md#nibi) | DRAC | [Nibi portal](https://portal.nibi.sharcnet.ca/) | [More details](https://docs.alliancecan.ca/wiki/Nibi/en) |
+| [Rorqual](drac/index.md#rorqual) | DRAC | [Rorqual portal](https://metrix.rorqual.calculquebec.ca/) | [More details](https://docs.alliancecan.ca/wiki/Rorqual/en) |
+| [Trillium](drac/index.md#trillium) | DRAC | [Trillium portal](https://my.scinet.utoronto.ca/) | [More details](https://docs.alliancecan.ca/wiki/Trillium/en) |
+| [TamIA](paice/index.md#tamia) | PAICE | [TamIA portal](https://portail.tamia.ecpia.ca/) | [More details](https://docs.alliancecan.ca/wiki/TamIA/en) |
+| [Killarney](paice/index.md#killarney) | PAICE | - | [More details](https://docs.alliancecan.ca/wiki/Killarney/en) |
+| [Vulcan](paice/index.md#vulcan) | PAICE | [Vulcan portal](https://portal.vulcan.alliancecan.ca/) | [More details](https://docs.alliancecan.ca/wiki/Vulcan/en) |

--- a/docs/technical_reference/clusters/mila/index.md
+++ b/docs/technical_reference/clusters/mila/index.md
@@ -6,10 +6,9 @@ This section seeks to provide factual information and policies on the Mila clust
     {% include-markdown "home/acknowledgement.md" start="<!-- START -->" %}
 
 <!--nav-->
-* [Roles and authorizations](../../../technical_reference/clusters/mila/roles_and_resources)
-* [Node profile description](../../../technical_reference/clusters/mila/nodes)
-* [Storage](../../../technical_reference/clusters/mila/storage)
-* [Partitions](../../../technical_reference/clusters/mila/partitions)
-* [Data sharing policies](../../../technical_reference/clusters/mila/sharing_policies)
-* [Data Transmission](../../../technical_reference/clusters/mila/data_transmission)
-* [Monitoring](../../../technical_reference/clusters/mila/monitoring)
+* [Roles and authorizations](roles_and_resources.md)
+* [Node profile description](nodes.md)
+* [Storage](storage.md)
+* [Data sharing policies](sharing_policies.md)
+* [Data Transmission](data_transmission.md)
+* [Monitoring](monitoring.md)

--- a/docs/technical_reference/clusters/mila/monitoring.md
+++ b/docs/technical_reference/clusters/mila/monitoring.md
@@ -12,7 +12,7 @@ This information is exposed in two ways:
 
     * `ssh -L 19999:<node>.server.mila.quebec:19999 -p 2222 login.server.mila.quebec`
     * or `ssh -L 19999:<node>.server.mila.quebec:19999 mila` if you have
-      already setup your [SSH Login](../../../../userguides/login/#ssh-secure-shell),
+      already setup your [SSH Login](../../../userguides/login.md#ssh-secure-shell),
   * then open http://localhost:19999 in your browser.
 * The Mila dashboard at [dashboard.server.mila.quebec](https://dashboard.server.mila.quebec/)
   exposes aggregated statistics with the use of [grafana](https://grafana.com/).

--- a/docs/technical_reference/clusters/mila/partitions.md
+++ b/docs/technical_reference/clusters/mila/partitions.md
@@ -13,10 +13,11 @@ resource limits, maximum run time, and priority. Use the Slurm flag
 ## Partition details
 
 Each job assigned with a priority can preempt jobs with a lower priority:
-`unkillable > main > long`.  Once preempted, the job is killed without notice
-and is automatically re-queued on the same partition until resources are available.
+`unkillable > main > long`. Once preempted, the job is killed without notice and
+is automatically re-queued on the same partition until resources are available.
 To leverage a different preemption mechanism, see the 
-[Handling preemption](../../../general_theory/multigpu/#handling-preemption) page.
+[Handling preemption](../../general_theory/multigpu.md#handling-preemption)
+page.
 
 | Partition          | Max Resource Usage        | Max Time    | Note                                                       |
 | -------------------| ------------------------- | ----------- | ---------------------------------------------------------- |
@@ -44,7 +45,7 @@ To leverage a different preemption mechanism, see the
     - **cn-n nodes**: H100 GPUs (8 GPUs per node, but only 4 can be used per job)
     
     For a complete list of node specifications and GPU details, see [Node
-    profile description](../nodes).
+    profile description](nodes.md).
 
 !!! note
     *As a convenience*, requesting the `unkillable`, `main`, or `long`

--- a/docs/technical_reference/clusters/mila/roles_and_resources.md
+++ b/docs/technical_reference/clusters/mila/roles_and_resources.md
@@ -21,7 +21,7 @@ if applicable, your co-supervisor.
 
 The Mila cluster is to be used for regular development and relatively small
 number of jobs (< 5). It is a heterogeneous cluster. It uses
-[Slurm](../../../../userguides/running_code) to schedule jobs.
+[Slurm](../../general_theory/slurm.md) to schedule jobs.
 
 
 ### Mila cluster versus Digital Research Alliance of Canada clusters

--- a/docs/technical_reference/clusters/mila/sharing_policies.md
+++ b/docs/technical_reference/clusters/mila/sharing_policies.md
@@ -2,14 +2,14 @@
 
 
 !!! note
-    [`/network/scratch`](../../../../technical_reference/clusters/mila/storage#scratch) aims to support [Access
+    [`/network/scratch`](storage.md#scratch) aims to support [Access
     Control Lists
     (ACLs)](https://en.wikipedia.org/wiki/Access-control_list) to allow
     collaborative work on rapidly changing data, e.g. work in process datasets,
     model checkpoints, etc.
 
 
-[`/network/projects`](../../../../technical_reference/clusters/mila/storage/#projects) aims to offer a collaborative
+[`/network/projects`](storage.md#projects) aims to offer a collaborative
 space for long-term projects. Data that should be kept for a longer period than
 90 days can be stored in that location but first a request to [Mila's
 helpdesk](https://it-support.mila.quebec) has to be made to create the project

--- a/docs/technical_reference/clusters/mila/storage.md
+++ b/docs/technical_reference/clusters/mila/storage.md
@@ -108,7 +108,7 @@ dataset's access group (ex.: `scannet_users`), your cluster's username and the
 approbation of the group owner. You can find the dataset's access group by
 listing the content of `/network/datasets/restricted` with the [ls command](https://cli-cheatsheet.readthedocs.io/en/latest/#ls).
 
-Those datasets are mirrored to the [Alliance clusters](../../../../technical_reference/clusters/drac) in
+Those datasets are mirrored to the [Alliance clusters](../drac/index.md) in
 `~/projects/rrg-bengioy-ad/data/curated/` if they follow Digital Research
 Alliance of Canada's [good practices on data](https://docs.alliancecan.ca/wiki/AI_and_Machine_Learning#Managing_your_datasets).
 To list the local datasets on an Alliance cluster, you can execute the following

--- a/docs/technical_reference/clusters/paice/index.md
+++ b/docs/technical_reference/clusters/paice/index.md
@@ -65,7 +65,7 @@ tier of a Mila researcher for the period which spans from April 7, 2026 to Sprin
 
 | Cluster                             | CPUs | RGUs allocated | # GPU equiv | Model               | Unrestricted internet |
 | ----------------------              | ---- | -------------- | ----------- | --------            | -----                 |
-| [TamIA](#TamIA) <br> tier1 + tier2  | 435  | 1738           | 143         | H100-80G <br> H200  | No                    |
+| [TamIA](#tamia) <br> tier1 + tier2  | 435  | 1738           | 143         | H100-80G <br> H200  | No                    |
 | [Killarney](#killarney) <br> tier3  | 0    | 794            | 75          | H100-80G <br> L40S  | Yes                   |
 | [Vulcan](#vulcan) <br> tier3        | 0    | 850            | 82          | L40S                | No                    |
 
@@ -140,7 +140,7 @@ found [here](https://docs.alliancecan.ca/wiki/Running_jobs#).
 When a series of experiments is finished, results should be transferred
 back to Mila servers.
 
-More details on storage can be found on the [DRAC Clusters guide](../drac/index.md#Storage) or
+More details on storage can be found on the [DRAC Clusters guide](../drac/index.md#storage) or
 on [DRAC wiki](https://docs.alliancecan.ca/wiki/Storage_and_file_management).
 
 ## Using CometML and Wandb

--- a/docs/technical_reference/general_theory/batch_scheduling.md
+++ b/docs/technical_reference/general_theory/batch_scheduling.md
@@ -115,4 +115,4 @@ allocate resources on their infrastructure.
 jobs to the main controller and add your job to the queue. Jobs are of 2 types:
 *batch* jobs and *interactive* jobs.
 
-For practical examples of Slurm commands on the Mila cluster, see [Running your code](../../../userguides/running_code/).
+For practical examples of Slurm commands on the Mila cluster, see [Running your code](slurm.md).

--- a/docs/technical_reference/general_theory/cluster_parts.md
+++ b/docs/technical_reference/general_theory/cluster_parts.md
@@ -51,7 +51,7 @@ for nodes, this is not always possible in the field of artificial intelligence
 as the hardware evolve rapidly as is being complemented by new hardware and so
 on. Hence, you will often read about computational node classes. Some of which
 might have different GPU models or even no GPU at all. For the Mila cluster you
-will find this information in the [Node profile description](../../../technical_reference/clusters/mila/nodes) section. For
+will find this information in the [Node profile description](../clusters/mila/nodes.md) section. For
 now, you should note that is important to keep in mind that you should be aware
 of *which* nodes your code is running on.  More on that later.
 
@@ -60,7 +60,7 @@ of *which* nodes your code is running on.  More on that later.
 Some computers on a cluster function to only store and serve files.  While the
 name of these computers might matter to some, as a user, you'll only be
 concerned about the path to the data. More on that in the [Processing
-data](../../../technical_reference/general_theory/data) section.
+data](data.md) section.
 
 ### Different nodes for different uses
 

--- a/docs/technical_reference/general_theory/datasets.md
+++ b/docs/technical_reference/general_theory/datasets.md
@@ -1,7 +1,7 @@
 # Contributing datasets
 
 If a dataset could help the research of others at Mila, [this form](https://docs.google.com/forms/d/e/1FAIpQLSe-EnHndjdxWWc5zXeIG-bWcOmsJXkG9_FoGkwMZuWDn7x4Kw/viewform) can be filled to request its addition
-to [/network/datasets](../../../technical_reference/clusters/mila/storage/#datasets).
+to [/network/datasets](../clusters/mila/storage.md#datasets).
 
 ## Publicly share a Mila dataset
 

--- a/docs/technical_reference/general_theory/portability.md
+++ b/docs/technical_reference/general_theory/portability.md
@@ -23,8 +23,8 @@ To achieve this, try to always keep in mind the following aspects:
   install and upgrade software and libraries for the former without worrying about
   breaking the latter (which you might not notice until weeks later, the next time
   you work on project B!) Isolation can be made easy using [uv](#uv), as well as
-  [Python Virtual environments](../../../technical_reference/general_theory/software_deps/#python-virtual-environments)
-  and, as a last resort, [containers](../../../technical_reference/general_theory/software_deps/#containers).
+  [Python Virtual environments](software_deps.md#python-virtual-environments)
+  and, as a last resort, [containers](software_deps.md#containers).
 
 
 {%
@@ -48,7 +48,7 @@ module load python/3.10
 
 ## On using containers
 
-Another option for creating portable code is [Using containers](#Using containers).
+Another option for creating portable code is [Using containers](#on-using-containers).
 
 Containers are a popular approach at deploying applications by packaging a lot
 of the required dependencies together. The most popular tool for this is
@@ -57,5 +57,5 @@ cluster (nor the other clusters from Digital Research Alliance of Canada).
 
 One popular mechanism for containerisation on a computational cluster is called
 [Podman](https://podman.io/).  This is the recommended approach for running
-containers on the Mila cluster. See the [Using containers section](../../../technical_reference/general_theory/containers) for more
+containers on the Mila cluster. See the [Using containers section](containers.md) for more
 details.

--- a/docs/technical_reference/general_theory/python.md
+++ b/docs/technical_reference/general_theory/python.md
@@ -81,7 +81,7 @@ several Python versions through the associated module which comes with pip. In
 order to install new packages, you will first have to create a personal space
 for them to be stored.  The usual solution (as it is the recommended solution
 on Digital Research Alliance of Canada clusters) is to use `virtual
-environments <https://virtualenv.pypa.io/en/stable/>`_, although [uv](./#uv) is now
+environments <https://virtualenv.pypa.io/en/stable/>`_, although [uv](#uv) is now
 the recommended way to manage Python installations, virtual environments and dependencies.
 
 !!! note

--- a/docs/technical_reference/general_theory/slurm.md
+++ b/docs/technical_reference/general_theory/slurm.md
@@ -460,7 +460,7 @@ To request 1 GPU with *at least* 48GB of memory use
 sbatch -c 4 --gres=gpu:48gb:1
 ```
 
-The full list of GPU and their features can be accessed [here](../../technical_reference/clusters/mila/nodes).
+The full list of GPU and their features can be accessed [here](../clusters/mila/nodes.md).
 
 ### Example script
 

--- a/docs/technical_reference/general_theory/slurm.md
+++ b/docs/technical_reference/general_theory/slurm.md
@@ -198,8 +198,8 @@ type of node/GPU, you can add specific feature requirements to your job
 submission command.
 
 To access those special nodes you need to request them explicitly by adding the
-flag `--constraint=<name>`.  The full list of nodes in the Mila Cluster can be
-accessed at [Node profile description](../../technical_reference/clusters/mila/nodes).
+flag `--constraint=<name>`. The full list of nodes in the Mila Cluster can be
+accessed at [Node profile description](../clusters/mila/nodes.md).
 
 *Examples:*
 
@@ -246,8 +246,8 @@ scancel 4323674
 
 ### Partitioning
 
-See the [list of Mila cluster partitions](../../technical_reference/clusters/mila/nodes). To request an unkillable job with 1 GPU, 4 CPUs, 10G of RAM and
-12h of computation do:
+See the [list of Mila cluster partitions](../clusters/mila/nodes.md). To request
+an unkillable job with 1 GPU, 4 CPUs, 10G of RAM and 12h of computation do:
 
 ```console
 sbatch --gres=gpu:1 -c 4 --mem=10G -t 12:00:00 --partition=unkillable <job.sh>

--- a/docs/technical_reference/general_theory/software_deps.md
+++ b/docs/technical_reference/general_theory/software_deps.md
@@ -20,7 +20,7 @@ might provide the `python` command to point to Python 3.7, another might
 activate CUDA version 11.0, another might provide the `torch` package, and so
 on.
 
-For more information, see [The module command](../../../technical_reference/clusters/drac/#modules).
+For more information, see [The module command](../clusters/drac/index.md#modules).
 
 ## Containers
 
@@ -34,7 +34,7 @@ packages using `apt`, modify settings as you would as a root user, and so on,
 but without interfering with your main installation. Once built, a container can
 be run on any compatible system.
 
-For more information, see [Using containers](../../../technical_reference/general_theory/containers).
+For more information, see [Using containers](containers.md).
 
 
 ## Python Virtual environments

--- a/docs/technical_reference/index.md
+++ b/docs/technical_reference/index.md
@@ -18,6 +18,6 @@
 
     Get definitions of commands and notions you may have encountered in this documentation
     
-    [:octicons-arrow-right-24: Check the glossary](../technical_reference/glossary)
+    [:octicons-arrow-right-24: Check the glossary](glossary.md)
     
 </div>

--- a/docs/toolbox/VSCode.md
+++ b/docs/toolbox/VSCode.md
@@ -24,7 +24,7 @@ The simplest way to do so is to install [milatools](https://github.com/mila-iqia
 that automatically allocates a CPU on a compute node for you. Then you can simply
 choose `mila-cpu` in the dropdown menu for remote SSH connection.
 
-The milatools package also provides the [mila code command](../../getting_started/#connect-to-the-cluster) which
+The milatools package also provides the [mila code command](../getting_started/index.md#connect-to-the-cluster) which
 gives you greater flexibility by letting you allocate more cores, RAM and/or GPUs.
 
 ## Activating an environment

--- a/docs/userguides/gpu_efficiency.md
+++ b/docs/userguides/gpu_efficiency.md
@@ -47,7 +47,7 @@ You can self-diagnose using these framework-agnostic methods.
 
 If you use WandB, go to the **System** tab of your run to find data on GPU
 utilization, CPU usage, and memory. See
-[Diagnose training bottlenecks](../../userguides/wandb.md#diagnose-training-bottlenecks)
+[Diagnose training bottlenecks](wandb.md#diagnose-training-bottlenecks)
 for details.
 
 ### Method B: The interactive check

--- a/docs/userguides/index.md
+++ b/docs/userguides/index.md
@@ -5,13 +5,13 @@ Check out our guides picturing different ways to use the cluster:
 | Guide | Quick description |
 | ----- | ----------------- |
 | [Manage Python Dependencies with uv](../userguides/python_uv.md) | Set up uv to manage project dependencies |
-| [Track Experiments with Weights & Biases (WandB)](../userguides/wandb) | Log metrics, organize runs, and run sweeps on the Mila cluster |
-| [Multi-Factor authentication](../Userguide_login_mfa) | Use MFA to access the Mila cluster |
-| [Logging in to the cluster](../userguides/login) | Log in to the Mila cluster |
-| [Launching jobs](../userguides/slurm_guide/) | Launch your jobs on the cluster |
-| [Identifying GPU waste](../userguides/gpu_efficiency/) | Understand GPU efficiency metrics, diagnose underutilization in your jobs and apply concrete best practices to improve throughput on the Mila cluster. |
-| [Sharing data with ACLs](../userguides/sharing_data) | Use ACLs to allow a user to share with another one a "playground" folder hierarchy in Mila's scratch filesystem at a location in a safe and secure fashion that allows both users to read, write, execute, search and delete each others' files |
-| [**[Minimal examples]** Software setup](../examples/frameworks/) | Set up Pytorch and Jax, and use Jax to run a single-GPU job |
-| [**[Minimal examples]** Distributed training](../examples/distributed/) | Learn to run single-GPU, multi-GPU and multi-node jobs |
-| [**[Minimal examples]** Good practices](../examples/good_practices/) | Discover some good practices aiming to ease the daily life |
-| [**[Minimal examples]** Advanced examples](../examples/advanced/) | Try this example of a multi-Node/multi-GPU ImageNet Training |
+| [Track Experiments with Weights & Biases (WandB)](wandb.md) | Log metrics, organize runs, and run sweeps on the Mila cluster |
+| [Multi-Factor authentication](../Userguide_login_mfa.md) | Use MFA to access the Mila cluster |
+| [Logging in to the cluster](login.md) | Log in to the Mila cluster |
+| [Launching jobs](slurm_guide/index.md) | Launch your jobs on the cluster |
+| [Identifying GPU waste](gpu_efficiency.md) | Understand GPU efficiency metrics, diagnose underutilization in your jobs and apply concrete best practices to improve throughput on the Mila cluster. |
+| [Sharing data with ACLs](sharing_data.md) | Use ACLs to allow a user to share with another one a "playground" folder hierarchy in Mila's scratch filesystem at a location in a safe and secure fashion that allows both users to read, write, execute, search and delete each others' files |
+| [**[Minimal examples]** Software setup](../examples/frameworks/index.md) | Set up Pytorch and Jax, and use Jax to run a single-GPU job |
+| [**[Minimal examples]** Distributed training](../examples/distributed/index.md) | Learn to run single-GPU, multi-GPU and multi-node jobs |
+| [**[Minimal examples]** Good practices](../examples/good_practices/index.md) | Discover some good practices aiming to ease the daily life |
+| [**[Minimal examples]** Advanced examples](../examples/advanced/index.md) | Try this example of a multi-Node/multi-GPU ImageNet Training |

--- a/docs/userguides/login.md
+++ b/docs/userguides/login.md
@@ -102,7 +102,7 @@ ssh -p 2222 <user>@login-X.login.server.mila.quebec
 ```
 
 This is a significant amount of typing. You are **strongly** encouraged to add
-a `mila` "alias" to your SSH configuration file (see [before](./#manual-ssh-configuration)
+a `mila` "alias" to your SSH configuration file (see [before](#manual-ssh-configuration)
 for how). With a correctly-configured SSH you can now simply run
 
 ```bash
@@ -120,7 +120,7 @@ to connect to a login node. The `mila` alias will be available to `ssh`,
 `scp`, `rsync` and all other programs that consult the SSH configuration file.
 
 Upon first login, you may be asked to enter your SSH key passphrase. Use the
-passphrase you used to create your SSH key [below](./#generating-an-ssh-private-key).
+passphrase you used to create your SSH key [below](#generating-an-ssh-private-key).
 
 Upon first login, you may also be asked whether you trust the ***Mila*** login
 servers' *own* SSH keys.
@@ -169,7 +169,7 @@ trust them!
     - Using ``tmux`` is acceptable. *(Mostly sleeps, managing the processes under its control)*
 
     !!! note
-        In a similar vein, you should not run VSCode remote SSH instances directly on login nodes, because even though they are typically not very computationally expensive, when many people do it, they add up! See [Visual Studio Code](../../toolbox/VSCode) for specific instructions.
+        In a similar vein, you should not run VSCode remote SSH instances directly on login nodes, because even though they are typically not very computationally expensive, when many people do it, they add up! See [Visual Studio Code](../toolbox/VSCode.md) for specific instructions.
 
 ## Connecting to compute nodes
 
@@ -249,8 +249,8 @@ Mila allows a maximum of 4 different public keys per user.
   read the informative material below, then proceed to
   generate them.
 - If you do not already have SSH keys, or are not sure if you have them, skip
-  to the instructions on how to generate them [here](./#checking-if-you-already-have-ssh-private-keys).
-- If you do have SSH keys, you can skip to [configuring SSH for access to Mila](./#manual-ssh-configuration).
+  to the instructions on how to generate them [here](#checking-if-you-already-have-ssh-private-keys).
+- If you do have SSH keys, you can skip to [configuring SSH for access to Mila](#manual-ssh-configuration).
 
 ### SSH Private Keys
 

--- a/docs/userguides/slurm_guide/basics.md
+++ b/docs/userguides/slurm_guide/basics.md
@@ -9,7 +9,7 @@ description: Ask for a resource allocation and launch tasks on the cluster.
 
 <div class="grid cards" markdown>
 
--   [:material-run-fast:{ .lg .middle } __Get Started with the Cluster__](../../../getting_started/)
+-   [:material-run-fast:{ .lg .middle } __Get Started with the Cluster__](../../getting_started/index.md)
     { .card }
 
     ---
@@ -35,10 +35,10 @@ Recurrent entities when we speak of Slurm are jobs, steps and tasks. If we want 
 * a job can have multiple steps
 * a step can run multiple tasks.
 
-[Check the technical reference for deeper information](../../../technical_reference/general_theory/slurm/#some-definitions)
+[Check the technical reference for deeper information](../../technical_reference/general_theory/slurm.md#some-definitions)
 
 ### Login nodes and compute nodes
-We will not dive into details here, because these concepts are explained in [What is a computer cluster?](../../../technical_reference/general_theory/cluster_parts/), but to sum up some notions, we focus on the two following types of nodes:
+We will not dive into details here, because these concepts are explained in [What is a computer cluster?](../../technical_reference/general_theory/cluster_parts.md), but to sum up some notions, we focus on the two following types of nodes:
 
 | Type of node | Use |
 | ------------ | --- |
@@ -68,7 +68,7 @@ Submitting tasks is done through two steps:
 
 ## Discover Slurm through an interactive job
 
-**1. Connect to your favorite cluster (see [this section](../../../getting_started/#verify-your-connection) for more information on the connection)**
+**1. Connect to your favorite cluster (see [this section](../../getting_started/index.md#verify-your-connection) for more information on the connection)**
 
 === "Steps"
     
@@ -79,7 +79,7 @@ Submitting tasks is done through two steps:
 
 === "More details"
 
-    Here, we arbitrary choose to connect to the Mila cluster. The command `ssh mila` works thanks to the configuration we previously set inside `~/.ssh/config`. This could be done by `mila init` (see [the Getting Started guide](../../getting_started/)).
+    Here, we arbitrary choose to connect to the Mila cluster. The command `ssh mila` works thanks to the configuration we previously set inside `~/.ssh/config`. This could be done by `mila init` (see [the Getting Started guide](../../getting_started/index.md)).
 
 
 **2. Submit a job**

--- a/docs/userguides/slurm_guide/tasks_communication.md
+++ b/docs/userguides/slurm_guide/tasks_communication.md
@@ -38,7 +38,7 @@ Thus, each example is based on three files:
 
 ### Introducing the different files
 
-(You can also check the ["Launch many jobs" example](../../../examples/good_practices/launch_many_jobs/).)
+(You can also check the ["Launch many jobs" example](../../examples/good_practices/launch_many_jobs/index.md).)
 
 === "job_torch.sh"
     ```bash
@@ -115,7 +115,7 @@ Thus, each example is based on three files:
     
     * The command `srun` creates tasks. The number of tasks is determined by the parameters `--ntasks` of our allocation. Here, we requested 4 tasks so the command will run 4 times in parallel tasks. These tasks run the command following `srun`, so each tasks will run `uv run python main_torch.py` or `uv run python main_jax.py`.
 
-    * `uv run` is used to ease the environment set up for our tasks. For more information, read [our `uv` guide on portability](../../../userguides/python_uv). It is followed by the name of the script we actually want to run in this environment.
+    * `uv run` is used to ease the environment set up for our tasks. For more information, read [our `uv` guide on portability](../python_uv.md). It is followed by the name of the script we actually want to run in this environment.
 
 
 === "main_torch.py"
@@ -207,7 +207,7 @@ Thus, each example is based on three files:
 
     **Environment variables**
 
-    In each file, we retrieve the Slurm environment variables `SLURM_PROCID`, `SLURM_LOCALID`, `SLURM_NTASKS` and `SLURM_NODEID`. Unlike the environment variables we defined previously (`MASTER_ADDR`, `MASTER_PORT` and `WORLD_SIZE`), these environment variables are specific to each tasks. More SLURM common environment variables are listed in [the technical reference](../../../technical_reference/general_theory/slurm).
+    In each file, we retrieve the Slurm environment variables `SLURM_PROCID`, `SLURM_LOCALID`, `SLURM_NTASKS` and `SLURM_NODEID`. Unlike the environment variables we defined previously (`MASTER_ADDR`, `MASTER_PORT` and `WORLD_SIZE`), these environment variables are specific to each tasks. More SLURM common environment variables are listed in [the technical reference](../../technical_reference/general_theory/slurm.md).
 
     ```python
     RANK = int(os.environ["SLURM_PROCID"])
@@ -323,7 +323,7 @@ Thus, each example is based on three files:
 
 <div class="grid cards" markdown>
 
--   [:material-multicast:{ .lg .middle } __Launch many jobs from same Shell script__](../../../examples/good_practices/launch_many_jobs/)
+-   [:material-multicast:{ .lg .middle } __Launch many jobs from same Shell script__](../../examples/good_practices/launch_many_jobs/index.md)
     { .card }
 
     ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,12 +1,20 @@
 site_name: Mila Technical Documentation
-# TODO: it might be possible to use something like
-# https://docs.mila.quebec/en/401/ as the site_url to avoid relying on relative
-# paths in the doc (../resource instead of /resource)
-site_url: https://docs.mila.quebec
+# site_url is resolved from READTHEDOCS_CANONICAL_URL at build time so canonical
+# links and the sitemap are correct on both production and PR previews (which are
+# served under a version-prefixed path). Falls back to the production URL locally.
+site_url: !ENV [READTHEDOCS_CANONICAL_URL, 'https://docs.mila.quebec']
 repo_name: mila-docs
 repo_url: https://github.com/mila-iqia/mila-docs
 docs_dir: docs
 edit_uri: edit/master/docs/
+
+# Surface broken internal links/anchors as warnings so RTD's fail_on_warning
+# turns them into a failing build (blocks the PR).
+validation:
+  links:
+    not_found: warn
+    anchors: warn
+    unrecognized_links: warn
 
 copyright: >
   Copyright &copy; 2026 Mila –

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,11 @@ repo_url: https://github.com/mila-iqia/mila-docs
 docs_dir: docs
 edit_uri: edit/master/docs/
 
+# Obsolete pre-sprint note kept in the repo but excluded from the build so it
+# doesn't shadow singularity/index.md.
+exclude_docs: |
+  singularity/README.md
+
 # Surface broken internal links/anchors as warnings so RTD's fail_on_warning
 # turns them into a failing build (blocks the PR).
 validation:


### PR DESCRIPTION
## Summary
Fixes every broken or unrecognized internal link and anchor that MkDocs reports, then turns those problems into build failures so link rot is caught in the PR preview instead of shipping. Also makes canonical URLs correct on Read the Docs preview builds.

## Changes
- Convert directory-style internal links (e.g. `../userguides/wandb`) to their MkDocs `.md` targets across ~30 pages, so they resolve correctly and portably on both docs.mila.quebec and the version-prefixed RTD preview paths.
- Repoint links to the removed `userguides/running_code` page at its replacement, `technical_reference/general_theory/slurm.md`.
- Fix broken anchors: case mismatches (`#Storage`, `#TamIA`, `#Using containers`), the multi-id `Before you begin` heading (split into per-admonition `[](){ #id }` anchors so all three aliases resolve), and the singularity `#nvidia` link now pointing to `nvidia.md`.
- Fix broken image paths in `ai/context.md` and a stale `wandb` anchor link in `gpu_efficiency.md`.
- `mkdocs.yml`: add a `validation.links` block (`not_found`/`anchors`/`unrecognized_links` → `warn`), exclude the obsolete `singularity/README.md`, and resolve `site_url` from `READTHEDOCS_CANONICAL_URL`.
- `.readthedocs.yaml`: set `fail_on_warning: true` so a new broken link/anchor blocks the PR.

## Notes
- Verified with `mkdocs build --strict`: exits 0 with zero warnings.
- Because `fail_on_warning` makes any warning fatal, future changes that trigger unrelated MkDocs warnings will also fail the build — intended, but worth knowing.
