### PR TITLE
Fix broken partitions links

### DIFF
--- a/docs/technical_reference/clusters/mila/index.md
+++ b/docs/technical_reference/clusters/mila/index.md
@@ -9,6 +9,7 @@ This section seeks to provide factual information and policies on the Mila clust
 * [Roles and authorizations](roles_and_resources.md)
 * [Node profile description](nodes.md)
 * [Storage](storage.md)
+* [Partitions](partitions.md)
 * [Data sharing policies](sharing_policies.md)
 * [Data Transmission](data_transmission.md)
 * [Monitoring](monitoring.md)

--- a/docs/technical_reference/general_theory/slurm.md
+++ b/docs/technical_reference/general_theory/slurm.md
@@ -246,7 +246,7 @@ scancel 4323674
 
 ### Partitioning
 
-See the [list of Mila cluster partitions](../clusters/mila/nodes.md). To request
+See the [list of Mila cluster partitions](../clusters/mila/partitions.md). To request
 an unkillable job with 1 GPU, 4 CPUs, 10G of RAM and 12h of computation do:
 
 ```console


### PR DESCRIPTION
## Summary
Fix partitions links in the Mila cluster index and slurm general theory pages.