### PR TITLE
Enlever lebrice des reviewers requis par défaut sur les nouvelles PRs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-*        @lebrice @satyaog @obilaniu @soline-b
-# docs/examples/        @lebrice @satyaog @obilaniu
+*        @satyaog @obilaniu @soline-b
+# docs/examples/        @satyaog @obilaniu


### PR DESCRIPTION
Je souhaite m'enlèver de la liste des reviewers requis par défaut pour les nouvelles PRs.

Je n'ai pas trouvé comment le faire par les settings de PR / review / etc, alors j'imagine qu'en m'enlevant comme code owner, ça devrait faire la même chose.