### PR TITLE
Remove outdated info on roles and resources on the Mila cluster 

### DIFF
--- a/docs/technical_reference/clusters/mila/index.md
+++ b/docs/technical_reference/clusters/mila/index.md
@@ -5,8 +5,7 @@ This section seeks to provide factual information and policies on the Mila clust
 !!! note "Acknowledging Mila"
     {% include-markdown "home/acknowledgement.md" start="<!-- START -->" %}
 
-<!--nav-->
-* [Roles and authorizations](roles_and_resources.md)
+* [Roles and computing resources](roles_and_resources.md)
 * [Node profile description](nodes.md)
 * [Storage](storage.md)
 * [Partitions](partitions.md)

--- a/docs/technical_reference/clusters/mila/roles_and_resources.md
+++ b/docs/technical_reference/clusters/mila/roles_and_resources.md
@@ -1,5 +1,9 @@
-# Roles and authorizations
+---
+title: Roles and computing resources
+description: How Mila affiliation status determines cluster access, and an overview of the Mila cluster's computing resources.
+---
 
+# Roles and computing resources
 
 Mila assigns one of two affiliation statuses to its professors and principal
 investigators:
@@ -15,46 +19,42 @@ co-supervisor are affiliated researchers, access is not granted.
 To determine your own status, check the Mila affiliation of your supervisor and,
 if applicable, your co-supervisor.
 
-
 ## Overview of available computing resources at Mila
 
+The Mila cluster is a heterogeneous cluster with a variety of node types
+(see [Node profile description](nodes.md)) and is to be used for regular development.
+It uses [Slurm](../../general_theory/slurm.md) to schedule jobs.
 
-The Mila cluster is to be used for regular development and relatively small
-number of jobs (< 5). It is a heterogeneous cluster. It uses
-[Slurm](../../general_theory/slurm.md) to schedule jobs.
-
-
-### Mila cluster versus Digital Research Alliance of Canada clusters
-
+### Mila cluster versus DRAC / PAICE clusters
 
 There are a lot of commonalities between the Mila cluster and the clusters from
-Digital Research Alliance of Canada (the Alliance). At the time being, the
-Alliance clusters where we have a large allocation of resources are `beluga`,
-`cedar`, `graham` and `narval`. We also have comparable computational resources
-in the Mila cluster, with more to come.
+[Digital Research Alliance of Canada (DRAC / the Alliance)](../drac/index.md)
+and [Pan-Canadian AI Compute Environment (PAICE)](../paice/index.md) (job
+scheduling with Slurm, filesystem, etc). At the time being, core researchers
+also have access to a large allocation of resources on the Alliance clusters
+through Mila's global allocation.
 
 The main distinguishing factor is that we have more control over our own cluster
-than we have over the ones at the Alliance. Notably, also, the compute nodes in
-the Mila cluster all have unrestricted access to the Internet, which is not the
-case in general for the Alliance clusters (although `cedar` does allow it).
+than we have over the external ones. Notably, the compute nodes in the Mila
+cluster all have unrestricted access to the Internet, which is not the case in
+general (although some clusters allow it).
 
-At the current time of this writing (June 2021), Mila students are advised to
-use a healthy diet of a mix of Mila and Alliance clusters. This is especially
-true in times when your favorite cluster is oversubscribed, because you can
-easily switch over to a different one if you are used to it.
+Mila students are advised to use a healthy diet of a mix of Mila and
+DRAC / PAICE clusters. This is especially true when a preferred cluster
+is oversubscribed and switching to a different cluster is possible.
 
+See the [clusters](../index.md) page for a list of all available clusters.
 
 ### Guarantees about one GPU as absolute minimum
-
 
 There are certain guarantees that the Mila cluster tries to honor when it comes
 to giving *at minimum* one GPU per student, all the time, to be used in
 interactive mode. This is strictly better than "one GPU per student on average"
-because it's a floor meaning that, at any time, you should be able to ask for
-your GPU, right now, and get it (although it might take a minute for the request
-to be processed by Slurm).
+because it's a floor meaning that, at any time, a GPU can be requested and
+obtained immediately (although processing the request through Slurm might
+take a minute).
 
-Interactive sessions are possible on the Alliance clusters, and there are
-generally special rules that allow you to get resources more easily if you
-request them for a very short duration (for testing code before queueing long
-jobs). You do not get the same guarantee as on the Mila cluster, however.
+Interactive sessions are also possible on the Alliance clusters, and there are
+generally special rules that provide quicker access to resources when
+requested for a very short duration (for testing code before queueing long
+jobs). The same guarantee does not apply on the Mila clusters, however.


### PR DESCRIPTION
## Summary
* Removed outdated info on Mila cluster roles and resources.
* Updated page title to the one used in the navigation bar.

## Updated pages
* [Roles and computing resources](https://mila-docs--468.org.readthedocs.build/en/468/technical_reference/clusters/mila/roles_and_resources/)