### PR TITLE
Document milalib as a way to get metrics

### DIFF
--- a/docs/userguides/compute_utilization_guidelines/profiling.md
+++ b/docs/userguides/compute_utilization_guidelines/profiling.md
@@ -80,8 +80,7 @@ Use the table below as a reference to evaluate SM occupancy:
 ## How to diagnose a job
 
 Self-diagnosis is possible using these framework-agnostic methods. The
-flowchart below outlines the decision path; the methods that follow explain
-how to read the underlying numbers.
+flowchart below outlines the decision path:
 
 ```mermaid
 flowchart TD
@@ -96,17 +95,53 @@ flowchart TD
     click A "../dashboard"
 ```
 
+Here are various ways you can obtain the required metrics (notably CPU/GPU
+utilization, VRAM usage, SM occupancy):
 
-### Method A: Weights & Biases
+### Method A: Milalib
+
+[Milalib](https://github.com/mila-iqia/milalib) is a utility you can run on
+the Mila cluster and some DRAC clusters to stream the relevant GPU and CPU
+metrics. For example, assuming [uv](../python_uv) is installed, the following
+command will output the `sm_occupancy` metric every 5 seconds:
+
+```bash
+uvx milalib monitor -i 5 -m sm_occupancy
+```
+
+You can run this command interactively, or as a background process in your
+jobs, with its output redirected to a file.
+
+### Method B: Weights & Biases
 
 In WandB, the **System** tab of a run shows data on GPU utilization, CPU
 usage, and memory. See
 [Diagnose training bottlenecks](../wandb.md#diagnose-training-bottlenecks)
 for details.
 
-### Method B: The interactive check
+!!! warning "Some measurements may be inaccurate"
+    WandB measures CPU and RAM utilization on the entire node (all cores
+    and all memory), even if you were only allocated part of it.
 
-During a job, `srun` into the allocated node and run a basic check:
+**Using milalib**
+
+We recommend using [milalib](https://github.com/mila-iqia/milalib) to add
+performance metrics to your wandb dashboard. Notably, milalib's CPU/RAM
+measurements should be accurate:
+
+```python
+import wandb
+from milalib.wandb import monitor
+
+wandb.init(...)  # initialize wandb first
+
+with monitor(interval=5):
+    # train your model
+```
+
+### Method C: The interactive check
+
+During a job, `srun` into the allocated node and run basic checks:
 
 ```bash
 # Check GPU utilization and power draw
@@ -115,7 +150,13 @@ nvidia-smi
 # High power draw (Watts) is usually a good signal of active GPU utilization.
 ```
 
-### Method C: The NVSMI log
+Or, using milalib:
+
+```bash
+uvx milalib monitor -i 1 -m gpu_util -m mem_util -m power -m sm_occupancy
+```
+
+### Method D: The NVSMI log
 
 When a job runs on the cluster, an output file is created with the default
 name `slurm-<JOB_ID>.out`. This file contains the job's output, along with an
@@ -237,7 +278,7 @@ NVSMI LOG section reporting metrics such as GPU and memory utilization.
       +-----------------------------------------------------------------------------------------+
     ```
 
-### Method D: TensorBoard visualization of PyTorch profiler data
+### Method E: TensorBoard visualization of PyTorch profiler data
 
 * [PyTorch profiler](https://docs.pytorch.org/tutorials/recipes/recipes/profiler_recipe.html)
   is a tool that measures the resource consumption of an experiment.
@@ -251,7 +292,7 @@ An example of TensorBoard usage on the cluster is described in the
 [Visualizing usage with PyTorch profiler and TensorBoard](using_tensorboard_and_pytorch_profiler.md)
 guide.
 
-### Method E: Cluster portals
+### Method F: Cluster portals
 
 Some clusters have a related portal for displaying data and metrics, such as
 resource usage or job history.

--- a/docs/userguides/compute_utilization_guidelines/profiling.md
+++ b/docs/userguides/compute_utilization_guidelines/profiling.md
@@ -102,8 +102,8 @@ utilization, VRAM usage, SM occupancy):
 
 [Milalib](https://github.com/mila-iqia/milalib) is a utility you can run on
 the Mila cluster and some DRAC clusters to stream the relevant GPU and CPU
-metrics. For example, assuming [uv](../python_uv) is installed, the following
-command will output the `sm_occupancy` metric every 5 seconds:
+metrics. For example, assuming [uv](../python_uv.md) is installed, the
+following command will output the `sm_occupancy` metric every 5 seconds:
 
 ```bash
 uvx milalib monitor -i 5 -m sm_occupancy


### PR DESCRIPTION
This PR introduces [milalib](https://github.com/mila-iqia/milalib) as a way to collect GPU utilization metrics. I added it as Method A. I also edited the wandb method to document a caveat (wandb sometimes won't log CPU/RAM usage properly) and document how to plug milalib's metrics into it. I also added a milalib invocation to the "interactive check" section.
