### PR TITLE
Add erratum for Mila global allocation for DRAC clusters

### DIFF
--- a/docs/home/cheatsheet.md
+++ b/docs/home/cheatsheet.md
@@ -50,3 +50,7 @@ The cheat sheet mentions that Tamia has H100 GPUs, but it also has nodes with 8 
 ### STACC is called Lynx
 
 The compute cluster originally planned to be called "STACC" is going to be called "Lynx" instead.
+
+### The URL to the Mila "mega allocation" for DRAC clusters is outdated
+
+The cheat sheet mentions a page on how to be added to Mila global allocation, but the URL is outdated. See the [DRAC clusters page](../technical_reference/clusters/drac/index.md#access-to-mila-global-allocation) for the correct page.


### PR DESCRIPTION
## Summary
* Add an erratum for the cheatsheet with the new URL of the page describing how to access Mila global allocation for DRAC clusters.

## Updated pages
* [Cheatsheet](https://mila-docs--475.org.readthedocs.build/en/475/technical_reference/cheatsheet/#the-url-to-the-mila-mega-allocation-for-drac-clusters-is-outdated)